### PR TITLE
Make libp2p_swarm:listen_addrs get addresses

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -65,7 +65,10 @@ tcp_listen_addrs(Socket) ->
             [multiaddr({Addr, Port}) ||
                 {_, Opts} <- IFAddrs, {addr, Addr} <- Opts, {flags, Flags} <- Opts,
                 size(Addr) == size(IP),
-                not lists:member(loopback, Flags)]
+                not lists:member(loopback, Flags),
+                %% filter out ipv6 link-local addresses
+                not (size(Addr) == 8 andalso element(1, Addr) == 16#fe80)
+            ]
     end.
 
 

--- a/test/identify_test.erl
+++ b/test/identify_test.erl
@@ -5,14 +5,14 @@
 
 identify_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
 
     {ok, Stream} = libp2p_swarm:dial(S1, S2Addr, "identify/1.0.0"),
     {S1Addr, _} = libp2p_connection:addr_info(Stream),
     {ok, IdentifyBin} = libp2p_framed_stream:recv(Stream),
     Identify = libp2p_identify:decode(IdentifyBin),
     ?assertEqual("identify/1.0.0", libp2p_identify:protocol_version(Identify)),
-    ?assertEqual([multiaddr:new(S2Addr)], libp2p_identify:listen_addrs(Identify)),
+    ?assert(lists:member(multiaddr:new(S2Addr), libp2p_identify:listen_addrs(Identify))),
     ?assertEqual(multiaddr:new(S1Addr), libp2p_identify:observed_addr(Identify)),
     ?assertMatch(("erlang-libp2p/" ++  _), libp2p_identify:agent_version(Identify)),
 

--- a/test/listen_test.erl
+++ b/test/listen_test.erl
@@ -1,0 +1,46 @@
+-module(listen_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+port0_test() ->
+    test_util:setup(),
+
+    {ok, Swarm} = libp2p_swarm:start(),
+    ?assertEqual([], libp2p_swarm:listen_addrs(Swarm)),
+
+    ?assertEqual(ok, libp2p_swarm:listen(Swarm, "/ip4/127.0.0.1/tcp/0")),
+
+    ?assertMatch(["/ip4/127.0.0.1/" ++ _], libp2p_swarm:listen_addrs(Swarm)),
+
+    ?assertEqual(ok, libp2p_swarm:listen(Swarm, "/ip6/::1/tcp/0")),
+    ?assertMatch(["/ip4/127.0.0.1/" ++ _, "/ip6/::1/" ++ _], libp2p_swarm:listen_addrs(Swarm)),
+
+    test_util:teardown_swarms([Swarm]).
+
+addr0_test() ->
+    test_util:setup(),
+
+    {ok, Swarm} = libp2p_swarm:start(0),
+
+    ListenAddrs = libp2p_swarm:listen_addrs(Swarm),
+    ?assert(length(ListenAddrs) > 0),
+
+    PAddrs = lists:map(fun(N) -> multiaddr:protocols(multiaddr:new(N)) end, ListenAddrs),
+    lists:foreach(fun([{"ip4", IP},{"tcp", Port}]) ->
+                          ?assertMatch({ok, _}, inet:parse_ipv4_address(IP)),
+                          ?assert(list_to_integer(Port) > 0)
+                  end, PAddrs),
+
+    test_util:teardown_swarms([Swarm]).
+
+already_test() ->
+    test_util:setup(),
+
+    {ok, Swarm} = libp2p_swarm:start("/ip4/127.0.0.1/tcp/0"),
+    [ListenAddr] = libp2p_swarm:listen_addrs(Swarm),
+
+    ?assertMatch({error, _}, libp2p_swarm:listen(Swarm, ListenAddr)),
+    ?assertMatch({error, _}, libp2p_swarm:start(ListenAddr)),
+
+    test_util:teardown_swarms([Swarm]).

--- a/test/multistream_test.erl
+++ b/test/multistream_test.erl
@@ -4,7 +4,7 @@
 
 client_ls_test() ->
     Swarms = [S1] = test_util:setup_swarms(1),
-    [Addr] = libp2p_swarm:listen_addrs(S1),
+    [Addr|_] = libp2p_swarm:listen_addrs(S1),
 
     {ok, Connection} = libp2p_transport_tcp:dial(Addr),
 
@@ -16,7 +16,7 @@ client_ls_test() ->
 
 client_negotiate_handler_test() ->
     Swarms = [S1] = test_util:setup_swarms(1),
-    [Addr] = libp2p_swarm:listen_addrs(S1),
+    [Addr|_] = libp2p_swarm:listen_addrs(S1),
 
     {ok, Connection} = libp2p_transport_tcp:dial(Addr),
 

--- a/test/serve_stream.erl
+++ b/test/serve_stream.erl
@@ -32,7 +32,7 @@ serve_loop(Connection, Parent) ->
     end.
 
 dial(FromSwarm, ToSwarm, Name) ->
-    [ToAddr] = libp2p_swarm:listen_addrs(ToSwarm),
+    [ToAddr|_] = libp2p_swarm:listen_addrs(ToSwarm),
     {ok, Stream} = libp2p_swarm:dial(FromSwarm, ToAddr, Name),
     receive
         {hello, Server} -> Server

--- a/test/session_test.erl
+++ b/test/session_test.erl
@@ -5,7 +5,7 @@
 
 open_close_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
     {ok, Session1} = libp2p_swarm:connect(S1, S2Addr),
     {Session1Addr, _} = libp2p_session:addr_info(Session1),
     {ok, Session2} = libp2p_swarm:connect(S2, Session1Addr),
@@ -30,7 +30,7 @@ open_close_test() ->
 
 ping_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
 
     {ok, Session} = libp2p_swarm:connect(S1, S2Addr),
     ?assertMatch({ok, _}, libp2p_session:ping(Session)),
@@ -41,7 +41,7 @@ ping_test() ->
 dial_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
     ok = libp2p_swarm:add_stream_handler(S2, "echo", {echo_stream, enter_loop, [self()]}),
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
 
     % Dial and see if the initial path got handled
     {ok, Stream} = libp2p_swarm:dial(S1, S2Addr, "echo/hello"),
@@ -82,7 +82,7 @@ stream_window_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
     ok = libp2p_swarm:add_stream_handler(S2, "echo", {echo_stream, enter_loop, [self()]}),
 
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
     {ok, Stream} = libp2p_swarm:dial(S1, S2Addr, "echo"),
 
     SmallData = <<41, 42, 43>>,
@@ -116,7 +116,7 @@ stream_timeout_test() ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
     ok = libp2p_swarm:add_stream_handler(S2, "echo", {echo_stream, enter_loop, [self()]}),
 
-    [S2Addr] = libp2p_swarm:listen_addrs(S2),
+    [S2Addr|_] = libp2p_swarm:listen_addrs(S2),
     {ok, Stream} = libp2p_swarm:dial(S1, S2Addr, "echo"),
 
     ?assertEqual({error, timeout}, libp2p_framed_stream:recv(Stream, 100)),

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -1,18 +1,25 @@
 -module(test_util).
 
--export([setup_swarms/0, setup_swarms/1, teardown_swarms/1,
+-export([setup/0, setup_swarms/0, setup_swarms/1, teardown_swarms/1,
          wait_until/3]).
 
-setup_swarms(0, Acc) ->
-    Acc;
-setup_swarms(N, Acc) ->
-    setup_swarms(N - 1, [libp2p_swarm:start(0) | Acc]).
-
-setup_swarms(N) when N >= 1 ->
+setup() ->
     application:ensure_all_started(ranch),
     %% application:ensure_all_started(lager),
     %% lager:set_loglevel(lager_console_backend, debug),
     %% lager:set_loglevel({lager_file_backend, "log/console.log"}, debug),
+    ok.
+
+setup_swarms(0, Acc) ->
+    Acc;
+setup_swarms(N, Acc) ->
+    setup_swarms(N - 1, [begin
+                             {ok, Pid} = libp2p_swarm:start(0),
+                             Pid
+                         end | Acc]).
+
+setup_swarms(N) when N >= 1 ->
+    setup(),
     setup_swarms(N, []).
 
 setup_swarms() ->


### PR DESCRIPTION
Fixes transport_tcp to fetch all ip addresses when an all "0" (global)
ip4/ip6 address is used.

This also changes libp2p_swarm:start() and start(0) to use
/ip4/0.0.0.0/tcp/0 as the start address.

Adds a few unit tests for this behavior