### PR TITLE
Madninja/fix gossip sessions

### DIFF
--- a/src/libp2p_multistream_server.erl
+++ b/src/libp2p_multistream_server.erl
@@ -62,12 +62,12 @@ handle_info({inert_read, _, _}, State=#state{connection=Conn,
                 {Key, {M, F}, LineRest} ->
                     {_, RemoteAddr} = libp2p_connection:addr_info(Conn),
                     write(Conn, Line),
-                    lager:info("Negotiated server handler for ~p: ~p", [RemoteAddr, Key]),
+                    lager:debug("Negotiated server handler for ~p: ~p", [RemoteAddr, Key]),
                     {exec, M, F, [Conn, LineRest, HandlerOpt, []]};
                 {Key, {M, F, A}, LineRest} ->
                     {_, RemoteAddr} = libp2p_connection:addr_info(Conn),
                     write(Conn, Line),
-                    lager:info("Negotiated server handler for ~p: ~p", [RemoteAddr, Key]),
+                    lager:debug("Negotiated server handler for ~p: ~p", [RemoteAddr, Key]),
                     {exec, M, F, [Conn, LineRest, HandlerOpt, A]};
                 error ->
                     write(Conn, "na"),
@@ -76,7 +76,7 @@ handle_info({inert_read, _, _}, State=#state{connection=Conn,
     end;
 handle_info(handshake, State=#state{connection=Conn}) ->
     {_, RemoteAddr} = libp2p_connection:addr_info(Conn),
-    lager:info("Starting handshake with client ~p", [RemoteAddr]),
+    lager:debug("Starting handshake with client ~p", [RemoteAddr]),
     case handshake(Conn) of
         ok ->
             fdset_return(Conn, State);

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -101,7 +101,7 @@ start_server_session(Ref, TID, Connection) ->
             % This should really not happen since the remote address
             % should be unique for most transports (e.g. a different
             % port for tcp)
-            exit(Pid, shutdown);
+            libp2p_session:close(Pid);
         false -> ok
     end,
     Handlers = [{Key, Handler} ||

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -100,7 +100,12 @@ start_server_session(Ref, TID, Connection) ->
         {ok, Pid} ->
             % This should really not happen since the remote address
             % should be unique for most transports (e.g. a different
-            % port for tcp)
+            % port for tcp). It _can_ happen if there is no listen
+            % port (a slow listen on start with a fast connect) that
+            % is reused which can cause the same inbound remote port
+            % to already be the target of a previous outbound
+            % connection (using a 0 source port). We prefer the new
+            % inbound connection, so close the other connection.
             libp2p_session:close(Pid);
         false -> ok
     end,

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -9,7 +9,7 @@
 
 
 -export_type([connection_handler/0]).
--export([for_addr/2, connect_to/4, start_client_session/3, start_server_session/3]).
+-export([for_addr/2, connect_to/4, find_session/3, start_client_session/3, start_server_session/3]).
 
 
 -spec for_addr(ets:tab(), string()) -> {ok, string(), {atom(), pid()}} | {error, term()}.
@@ -31,11 +31,11 @@ for_addr(TID, Addr) ->
 -spec connect_to(string(), libp2p_swarm:connect_opts(), pos_integer(), ets:tab())
                 -> {ok, string(), libp2p_session:pid()} | {error, term()}.
 connect_to(Addr, Options, Timeout, TID) ->
-    case libp2p_transport:for_addr(TID, Addr) of
-        {ok, ConnAddr, {Transport, TransportPid}} ->
-            case libp2p_config:lookup_session(TID, ConnAddr, Options) of
-                {ok, Pid} -> {ok, ConnAddr, Pid};
-                false ->
+    case find_session([Addr], Options, TID) of
+        {ok, ConnAddr, SessionPid} -> {ok, ConnAddr, SessionPid};
+        {error, not_found} ->
+            case for_addr(TID, Addr) of
+                {ok, ConnAddr, {Transport, TransportPid}} ->
                     lager:info("~p connecting to ~p", [Transport, ConnAddr]),
                     try Transport:connect(TransportPid, ConnAddr, Options, Timeout, TID) of
                         {error, Error} -> {error, Error};
@@ -46,6 +46,23 @@ connect_to(Addr, Options, Timeout, TID) ->
             end;
         {error, Error} -> {error, Error}
     end.
+
+%% @doc Find a existing session for one of a given list of
+%% multiaddrs. Returns `{error not_found}' if no session is found.
+-spec find_session([string()], libp2p_config:opts(), ets:tab())
+                  -> {ok, string(), libp2p_session:pid()} | {error, term()}.
+find_session([], _Options, _TID) ->
+    {error, not_found};
+find_session([Addr | Tail], Options, TID) ->
+    case for_addr(TID, Addr) of
+        {ok, ConnAddr, _} ->
+            case libp2p_config:lookup_session(TID, ConnAddr, Options) of
+                {ok, Pid} -> {ok, ConnAddr, Pid};
+                false -> find_session(Tail, Options, TID)
+            end;
+        {error, Error} -> {error, Error}
+    end.
+
 
 %%
 %% Session negotiation
@@ -76,7 +93,7 @@ start_client_session(TID, Addr, Connection) ->
     end.
 
 
--spec start_server_session(reference(), ets:tab(), libp2p_connection:connection()) -> {ok, pid()}.
+-spec start_server_session(reference(), ets:tab(), libp2p_connection:connection()) -> {ok, pid()} | {error, term()}.
 start_server_session(Ref, TID, Connection) ->
     {_, RemoteAddr} = libp2p_connection:addr_info(Connection),
     case libp2p_config:lookup_session(TID, RemoteAddr) of
@@ -84,7 +101,7 @@ start_server_session(Ref, TID, Connection) ->
             % This should really not happen since the remote address
             % should be unique for most transports (e.g. a different
             % port for tcp)
-            error({already_connected, RemoteAddr});
+            {error, {already_connected, RemoteAddr}};
         false ->
             Handlers = [{Key, Handler} ||
                            {Key, {Handler, _}} <- libp2p_config:lookup_connection_handlers(TID)],

--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -177,14 +177,6 @@ terminate(_Reason, #state{connection=Connection}) ->
 %% Internal
 %%
 
-config_get(#state{tid=TID}, _Key, Default) when TID == undefined ->
-    Default;
-config_get(#state{tid=TID}, Key, Default) ->
-    case ets:lookup(TID, Key) of
-        [] -> Default;
-        [Value] -> Value
-    end.
-
 fdset(Connection, State) ->
     case libp2p_connection:fdset(Connection) of
         ok -> ok;
@@ -225,12 +217,13 @@ encode_header(#header{type=Type, flags=Flags, stream_id=StreamID, length=Length}
 %%
 
 -spec ping_send(pid(), #state{}) -> {ok, #state{}} | {error, term()}.
-ping_send(From, State=#state{next_ping_id=NextPingID, pings=Pings}) ->
+ping_send(From, State=#state{tid=TID, next_ping_id=NextPingID, pings=Pings}) ->
     case session_send(header_ping(NextPingID), State) of
         {error, Error} -> {error, Error};
         ok ->
-            TimerRef = erlang:send_after(config_get(State, {yamux, write_timeout}, ?DEFAULT_WRITE_TIMEOUT),
-                                         self(), {timeout_ping, NextPingID}),
+            Opts = libp2p_swarm:opts(TID, []),
+            WriteTimeOut = libp2p_config:get_opt(Opts, [?MODULE, write_timeout], ?DEFAULT_WRITE_TIMEOUT),
+            TimerRef = erlang:send_after(WriteTimeOut, self(), {timeout_ping, NextPingID}),
             Pings2 = maps:put(NextPingID, {From, erlang:system_time(millisecond), TimerRef}, Pings),
             {ok, State#state{next_ping_id=NextPingID + 1, pings=Pings2}}
     end.


### PR DESCRIPTION
Seed nodes in the gossip group mean that the gossip group can start connecting _before_ a listen address is bound on the group's node. This then causes the receiving node to not be sure if it's already connected to the source. 

We deal with in a lose manner by dropping an existing connection if someone we're already connected to connects to us.