### PR TITLE
Madninja/deferred acks

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -4,12 +4,12 @@
 
 -behavior(libp2p_framed_stream).
 
--callback handle_data(State::any(), Ref::any(), Msg::binary()) -> ok  | {error, term()}.
+-callback handle_data(State::any(), Ref::any(), Msg::binary()) -> ok | defer | {error, term()}.
 -callback accept_stream(State::any(), MAddr::string(), Stream::pid(), Path::string()) ->
     {ok, Ref::any()} | {error, term()}.
 
 %% libp2p_framed_stream
--export([server/4, client/2, init/3, handle_data/3, handle_send/5]).
+-export([server/4, client/2, init/3, handle_data/3, handle_send/5, handle_cast/3]).
 
 
 -record(state,
@@ -42,21 +42,47 @@ init(client, Connection, [AckRef, AckModule, AckState]) ->
     {ok, #state{connection=Connection,
                 ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}}.
 
-handle_data(_Kind, Data, State=#state{send_from=From, ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}) ->
+handle_data(Kind, Data, State=#state{send_from=From, ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}) ->
     case libp2p_ack_stream_pb:decode_msg(Data, libp2p_data_pb) of
-        #libp2p_data_pb{ack=true, seq=_Seq, data=_} when From /= undefined ->
-            gen_server:reply(From, ok),
-            {noreply, State#state{send_from=undefined}};
-        #libp2p_data_pb{ack=false, data=Bin, seq=Seq} ->
+        #libp2p_data_pb{ack=req, data=Bin, seq=Seq} ->
+            %% Inbound request to handle a message
             case AckModule:handle_data(AckState, AckRef, Bin) of
+                defer ->
+                    %% Send back a defer message to keep the sender
+                    %% waiting for the final ack.
+                    lager:debug("HANDLE_DATA DEFER ~p:~p", [Kind, Seq]),
+                    Ack = #libp2p_data_pb{ack=defer, seq=Seq},
+                    {noreply, State, libp2p_ack_stream_pb:encode_msg(Ack)};
                 ok ->
-                    Ack = #libp2p_data_pb{ack=true, seq=Seq},
+                    %% Handler is ok with the message. Ack back to the
+                    %% sender.
+                    lager:debug("HANDLE_DATA OK ~p:~p", [Kind, Seq]),
+                    Ack = #libp2p_data_pb{ack=ack, seq=Seq},
                     {noreply, State, libp2p_ack_stream_pb:encode_msg(Ack)};
                 {error, Reason} ->
                     {stop, {error, Reason}, State}
-            end
+            end;
+        #libp2p_data_pb{ack=defer, seq=Seq, data=_} ->
+            %% When we receive a defer we do _not_ reply back to teh
+            %% original caller. This way we block the sender until the
+            %% actual ack is received
+            lager:debug("DEFER! ~p:~p", [Kind, Seq]),
+            {noreply, State};
+        #libp2p_data_pb{ack=ack, seq=Seq, data=_} when From /= undefined  ->
+            lager:debug(" ACK! ~p:~p", [Kind, Seq]),
+            gen_server:reply(From, ok),
+            {noreply, State#state{send_from=undefined}};
+        Other ->
+            lager:notice("Unexpacted ack frame: ~p", [Other]),
+            {noreply, State}
     end.
 
 handle_send(_Kind, From, Data, Timeout, State=#state{msg_seq=Seq}) ->
-    Msg = #libp2p_data_pb{data=Data, seq=Seq},
+    Msg = #libp2p_data_pb{ack=req, data=Data, seq=Seq},
     {ok, noreply, libp2p_ack_stream_pb:encode_msg(Msg), Timeout, State#state{msg_seq=Seq + 1, send_from=From}}.
+
+
+handle_cast(Kind, ack, State=#state{msg_seq=Seq}) ->
+    lager:debug("CAST ACK! ~p:~p", [Kind, Seq]),
+    Msg = #libp2p_data_pb{ack=ack, seq=Seq},
+    {noreply, State, libp2p_ack_stream_pb:encode_msg(Msg)}.

--- a/src/group/libp2p_ack_stream.proto
+++ b/src/group/libp2p_ack_stream.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
 
 enum status {
-  req = 0;
-  ack = 1;
-  defer = 2;
+  ack = 0;
+  defer = 1;
 }
 
-message data {
-  status ack = 1;
-  bytes data = 2;
-  uint32 seq = 3;
+message ack_frame {
+  oneof frame {
+    status ack = 1;
+    bytes data = 2;
+  }
 }

--- a/src/group/libp2p_ack_stream.proto
+++ b/src/group/libp2p_ack_stream.proto
@@ -1,7 +1,13 @@
 syntax = "proto3";
 
+enum status {
+  req = 0;
+  ack = 1;
+  defer = 2;
+}
+
 message data {
-  bool ack = 1;
+  status ack = 1;
   bytes data = 2;
   uint32 seq = 3;
 }

--- a/src/group/libp2p_group_relcast.erl
+++ b/src/group/libp2p_group_relcast.erl
@@ -4,7 +4,7 @@
 
 -export_type([opt/0]).
 
--export([start_link/3, get_opt/3, handle_input/2]).
+-export([start_link/3, get_opt/3, handle_input/2, handle_ack/2]).
 
 -spec start_link(ets:tab(), GroupID::string(), Args::[any()])
                 -> {ok, pid()} | {error, term()}.
@@ -15,6 +15,10 @@ start_link(TID, GroupID, Args) ->
 handle_input(GroupPid, Msg) ->
     Server = libp2p_group_relcast_sup:server(GroupPid),
     libp2p_group_relcast_server:handle_input(Server, Msg).
+
+handle_ack(GroupPid, Index) ->
+    Server = libp2p_group_relcast_sup:server(GroupPid),
+    libp2p_group_relcast_server:handle_ack(Server, Index).
 
 -spec get_opt(libp2p_config:opts(), atom(), any()) -> any().
 get_opt(Opts, Key, Default) ->

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -238,7 +238,7 @@ dispatch_message(Index, Key, Msg, State=#state{self_index=SelfIndex}) ->
             %% Dispatch a message to self directly
             Parent = self(),
             %% lager:debug("~p DISPATCHING TO ~p: ~p", [SelfIndex, Index, base58:binary_to_base58(Key)]),
-            spawn_link(fun() ->
+            spawn(fun() ->
                           Result = handle_data(Parent, Index, Msg),
                           libp2p_group_server:send_result(Parent, {Key, Index}, Result)
                   end),

--- a/src/libp2p_multistream_server.erl
+++ b/src/libp2p_multistream_server.erl
@@ -21,7 +21,6 @@ start_link(Ref, Connection, Handlers, HandlerOpt) ->
 
 init({Ref, Connection, Handlers, HandlerOpt}) ->
     ok = libp2p_connection:acknowledge(Connection, Ref),
-    lager:info("Acknowledged connection"),
     self() ! handshake,
     loop(#state{connection=Connection, handlers=Handlers, handler_opt=HandlerOpt}).
 

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -88,12 +88,12 @@ start_client_session(TID, Addr, Connection) ->
             {ok, SessionPid} = supervisor:start_child(SessionSup, ChildSpec),
             case libp2p_connection:controlling_process(Connection, SessionPid) of
                 ok ->
-                    lager:info("set controlling process of ~p to ~p", [Connection, SessionPid]),
                     libp2p_config:insert_session(TID, Addr, SessionPid),
                     libp2p_identify:spawn_identify(SessionPid, libp2p_swarm_sup:server(TID), client),
                     {ok, SessionPid};
                 {error, Error} ->
-                    lager:error("setting the controlling process for ~p to ~p failed ~p", [Connection, SessionPid, Error]),
+                    lager:error("Changing controlling process for ~p to ~p failed ~p",
+                                [Connection, SessionPid, Error]),
                     libp2p_connection:close(Connection),
                     {error, Error}
             end

--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -110,7 +110,6 @@ send_data(Pid, Header, Data, Timeout) ->
 init({TID, Connection, _Path, NextStreamId}) ->
     erlang:process_flag(trap_exit, true),
     {ok, StreamSup} = supervisor:start_link(libp2p_simple_sup, []),
-    lager:info("Starting yamux session using connection ~p with next stream id ~p", [Connection, NextStreamId]),
     SendPid = spawn_link(libp2p_connection:mk_async_sender(self(), Connection)),
     State = #state{connection=Connection, tid=TID,
                    stream_sup=StreamSup,
@@ -195,7 +194,6 @@ handle_cast(Msg, State) ->
 
 
 terminate(Reason, #state{connection=Connection, send_pid=SendPid}) ->
-    lager:info("Yamux session terminating"),
     fdclr(Connection),
     erlang:exit(SendPid, Reason),
     libp2p_connection:close(Connection).

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -1,14 +1,18 @@
 -module(group_relcast_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([unicast_test/1, multicast_test/1, restart_test/1]).
+-export([unicast_test/1, multicast_test/1, defer_test/1, restart_test/1]).
 
 all() ->
     [ %% restart_test,
       unicast_test,
-      multicast_test
+      multicast_test,
+      defer_test
     ].
 
+init_per_testcase(defer_test, Config) ->
+    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]}]),
+    [{swarms, Swarms} | Config];
 init_per_testcase(_, Config) ->
     Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]}]),
     [{swarms, Swarms} | Config].
@@ -112,15 +116,45 @@ multicast_test(Config) ->
 
     ok.
 
-receive_messages(Acc) ->
-    receive
-        Msg ->
-            io:format("MSG ~p", [Msg]),
-            receive_messages([Msg | Acc])
-    after 5000 ->
-            Acc
-    end.
 
+defer_test(Config) ->
+    Swarms = [S1, S2] = proplists:get_value(swarms, Config),
+
+    test_util:connect_swarms(S1, S2),
+
+    await_peerbooks(Swarms),
+
+    Members = [libp2p_swarm:address(S) || S <- Swarms],
+
+    %% G1 takes input and unicasts it to G2
+    G1Args = [relcast_handler, [Members, input_unicast(2), handle_msg(ok)]],
+    {ok, G1} = libp2p_swarm:add_group(S1, "test", libp2p_group_relcast, G1Args),
+
+    %% G2 handles a message by deferring it
+    G2Args = [relcast_handler, [Members, input_unicast(1), handle_msg(defer)]],
+    {ok, G2} = libp2p_swarm:add_group(S2, "test", libp2p_group_relcast, G2Args),
+
+    libp2p_group_relcast:handle_input(G1, <<"hello">>),
+    lager:debug("POST HANDLE INPUT"),
+
+    %% G2 should receive the message from G1 even though is defers it
+    [{handle_msg, 1, <<"hello">>}] = receive_messages([], 1000),
+    lager:debug("POST FIRST RECEIVE"),
+
+    %% Then we ack it by telling G2 to ack for G1
+    libp2p_group_relcast:handle_ack(G2, 1),
+    lager:debug("POST HANDLE_ACK"),
+
+    %% Send a message from G2 to G1
+    libp2p_group_relcast:handle_input(G2, <<"hello2">>),
+
+    %% Which G1 should see as a message from G2
+    [{handle_msg, 2, <<"hello2">>}] = receive_messages([], 1000),
+
+    ok.
+
+
+    %% Then we ack
 
 restart_test(_Config) ->
     %% Restarting a relcast group should resend outbound messages that
@@ -147,4 +181,15 @@ handle_msg(Resp) ->
     fun(Index, Msg) ->
             Parent ! {handle_msg, Index, Msg},
             Resp
+    end.
+
+receive_messages(Acc) ->
+    receive_messages(Acc, 5000).
+
+receive_messages(Acc, Timeout) ->
+    receive
+        Msg ->
+            receive_messages([Msg | Acc])
+    after Timeout ->
+            Acc
     end.

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -135,15 +135,12 @@ defer_test(Config) ->
     {ok, G2} = libp2p_swarm:add_group(S2, "test", libp2p_group_relcast, G2Args),
 
     libp2p_group_relcast:handle_input(G1, <<"hello">>),
-    lager:debug("POST HANDLE INPUT"),
 
     %% G2 should receive the message from G1 even though is defers it
     [{handle_msg, 1, <<"hello">>}] = receive_messages([], 1000),
-    lager:debug("POST FIRST RECEIVE"),
 
     %% Then we ack it by telling G2 to ack for G1
     libp2p_group_relcast:handle_ack(G2, 1),
-    lager:debug("POST HANDLE_ACK"),
 
     %% Send a message from G2 to G1
     libp2p_group_relcast:handle_input(G2, <<"hello2">>),


### PR DESCRIPTION
This adds deferred acks to ack_stream. A deferred ack means that the caller of a ack_stream send will be blocked when a defer message is returned from the remote side. Once an ack is receiver the send returns normally. 