### PR TITLE
Madninja/relcast restart issues

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -7,18 +7,29 @@
 -callback handle_data(State::any(), Ref::any(), Msg::binary()) -> ok | defer | {error, term()}.
 -callback accept_stream(State::any(), MAddr::string(), Stream::pid(), Path::string()) ->
     {ok, Ref::any()} | {error, term()}.
--callback handle_ack(State::any(), Ref::any()) ->ok.
+-callback handle_ack(State::any(), Ref::any(), Ack::ok | defer) -> ok.
 
+%% API
+-export([send_ack/1]).
 %% libp2p_framed_stream
--export([server/4, client/2, init/3, handle_data/3, handle_send/5, handle_cast/3]).
+-export([server/4, client/2, init/3, handle_data/3, handle_send/5, handle_info/3]).
 
 
 -record(state,
         { connection :: libp2p_connection:connection(),
           ack_module :: atom(),
           ack_state :: any(),
-          ack_ref :: any()
+          ack_ref :: any(),
+          send_from=undefined :: term() | undefined
         }).
+
+%% API
+%%
+
+-spec send_ack(pid()) -> ok.
+send_ack(Pid) ->
+    Pid ! send_ack,
+    ok.
 
 %% libp2p_framed_stream
 %%
@@ -41,30 +52,28 @@ init(client, Connection, [AckRef, AckModule, AckState]) ->
     {ok, #state{connection=Connection,
                 ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}}.
 
-handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}) ->
+handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_state=AckState, send_from=From}) ->
     case libp2p_ack_stream_pb:decode_msg(Data, libp2p_ack_frame_pb) of
         #libp2p_ack_frame_pb{frame={data, Bin}} ->
             %% Inbound request to handle a message
             case AckModule:handle_data(AckState, AckRef, Bin) of
-                defer ->
-                    %% Send back a defer message to keep the sender
-                    %% waiting for the final ack.
-                    Ack = #libp2p_ack_frame_pb{frame={ack, defer}},
-                    {noreply, State, libp2p_ack_stream_pb:encode_msg(Ack)};
-                ok ->
-                    %% Handler is ok with the message. Ack back to the
-                    %% sender.
-                    Ack = #libp2p_ack_frame_pb{frame={ack, ack}},
-                    {noreply, State, libp2p_ack_stream_pb:encode_msg(Ack)};
                 {error, Reason} ->
-                    {stop, {error, Reason}, State}
+                    {stop, {error, Reason}, State};
+                Response ->
+                    %% Send back an ok or defer message
+                    Ack = #libp2p_ack_frame_pb{frame={ack, Response}},
+                    {noreply, State, libp2p_ack_stream_pb:encode_msg(Ack)}
             end;
-        #libp2p_ack_frame_pb{frame={ack, defer}} ->
-            %% When we receive a defer we do _not_ invoke the
-            %% handler. The message is not yet complete
-            {noreply, State};
-        #libp2p_ack_frame_pb{frame={ack, ack}} ->
-            AckModule:handle_ack(AckState, AckRef),
+        #libp2p_ack_frame_pb{frame={ack, Ack}} when From /= undefined  ->
+            %% When we receive an ack (ok or defer) from the remote side we
+            %% unblock the caller and pass the response back.
+            gen_server:reply(From, Ack),
+            {noreply, State#state{send_from=undefined}};
+        #libp2p_ack_frame_pb{frame={ack, Ack}} ->
+            %% When we receive an ack response (ok or defer) from the
+            %% remote side without a blocked caller we call the
+            %% handler to deal with it.
+            AckModule:handle_ack(AckState, AckRef, Ack),
             {noreply, State};
         _Other ->
             {noreply, State}
@@ -72,9 +81,8 @@ handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_
 
 handle_send(_Kind, From, Data, Timeout, State=#state{}) ->
     Msg = #libp2p_ack_frame_pb{frame={data, Data}},
-    {ok, {reply, From, ok}, libp2p_ack_stream_pb:encode_msg(Msg), Timeout, State}.
+    {ok, noreply, libp2p_ack_stream_pb:encode_msg(Msg), Timeout, State#state{send_from=From}}.
 
-
-handle_cast(_Kind, ack, State=#state{}) ->
-    Msg = #libp2p_ack_frame_pb{frame={ack, ack}},
+handle_info(_Kind, send_ack, State=#state{}) ->
+    Msg = #libp2p_ack_frame_pb{frame={ack, ok}},
     {noreply, State, libp2p_ack_stream_pb:encode_msg(Msg)}.

--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -60,9 +60,8 @@ handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_
                     {stop, {error, Reason}, State}
             end;
         #libp2p_ack_frame_pb{frame={ack, defer}} ->
-            %% When we receive a defer we do _not_ reply back to teh
-            %% original caller. This way we block the sender until the
-            %% actual ack is received
+            %% When we receive a defer we do _not_ invoke the
+            %% handler. The message is not yet complete
             {noreply, State};
         #libp2p_ack_frame_pb{frame={ack, ack}} ->
             AckModule:handle_ack(AckState, AckRef),

--- a/src/group/libp2p_ack_stream.proto
+++ b/src/group/libp2p_ack_stream.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 enum status {
-  ack = 0;
+  ok = 0;
   defer = 1;
 }
 

--- a/src/group/libp2p_group_relcast.erl
+++ b/src/group/libp2p_group_relcast.erl
@@ -4,7 +4,7 @@
 
 -export_type([opt/0]).
 
--export([start_link/3, get_opt/3, handle_input/2, handle_ack/2, info/1, queues/1]).
+-export([start_link/3, get_opt/3, handle_input/2, send_ack/2, info/1, queues/1]).
 
 -spec start_link(ets:tab(), GroupID::string(), Args::[any()])
                 -> {ok, pid()} | {error, term()}.
@@ -16,9 +16,9 @@ handle_input(GroupPid, Msg) ->
     Server = libp2p_group_relcast_sup:server(GroupPid),
     libp2p_group_relcast_server:handle_input(Server, Msg).
 
-handle_ack(GroupPid, Index) ->
+send_ack(GroupPid, Index) ->
     Server = libp2p_group_relcast_sup:server(GroupPid),
-    libp2p_group_relcast_server:handle_ack(Server, Index).
+    libp2p_group_relcast_server:send_ack(Server, Index).
 
 -spec get_opt(libp2p_config:opts(), atom(), any()) -> any().
 get_opt(Opts, Key, Default) ->

--- a/src/group/libp2p_group_relcast_handler.erl
+++ b/src/group/libp2p_group_relcast_handler.erl
@@ -14,5 +14,10 @@
 -type handler_result() :: {State::handler_state(), ok | defer | {send, [message()]}}.
 
 -type message() ::
-        {unicast, Index::pos_integer(), Msg::binary()} |
-        {multicast, Msg::binary()}.
+        {unicast, Index::pos_integer(), Msg::message_value()} |
+        {multicast, Msg::message_value()}.
+
+-type message_key_prefix() :: <<_:128>>.
+-type message_value() ::
+        {message_key_prefix(), binary()} |
+        binary().

--- a/src/group/libp2p_group_relcast_handler.erl
+++ b/src/group/libp2p_group_relcast_handler.erl
@@ -11,10 +11,7 @@
 
 -type handler_state() :: binary().
 
--type handler_result() ::
-        {State::handler_state(), ok} |
-        {State, {send, [message()]}} |
-        {State, stop, Reason::any()}.
+-type handler_result() :: {State::handler_state(), ok | defer | {send, [message()]}}.
 
 -type message() ::
         {unicast, Index::pos_integer(), Msg::binary()} |

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -7,17 +7,17 @@
 -behavior(libp2p_info).
 
 %% API
--export([start_link/4, handle_input/2, handle_ack/2, info/1]).
+-export([start_link/4, handle_input/2, send_ack/2, info/1]).
 %% gen_server
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 %% libp2p_ack_stream
--export([handle_data/3, accept_stream/4]).
+-export([handle_data/3, handle_ack/2, accept_stream/4]).
 
 -record(worker,
        { target :: string(),
          index :: pos_integer(),
          pid :: pid() | self,
-         ready=false :: boolean()
+         msg_key=undefined :: msg_key() | undefined
        }).
 
 -record(state,
@@ -46,8 +46,8 @@
 handle_input(Pid, Msg) ->
     gen_server:cast(Pid, {handle_input, Msg}).
 
-handle_ack(Pid, Index) ->
-    erlang:send(Pid, {handle_ack, Index}).
+send_ack(Pid, Index) ->
+    erlang:send(Pid, {send_ack, Index}).
 
 info(Pid) ->
     catch gen_server:call(Pid, info).
@@ -55,6 +55,9 @@ info(Pid) ->
 %% libp2p_ack_stream
 handle_data(Pid, Ref, Bin) ->
     gen_server:call(Pid, {handle_data, Ref, Bin}, timer:seconds(30)).
+
+handle_ack(Pid, Ref) ->
+    gen_server:cast(Pid, {handle_ack, Ref}).
 
 accept_stream(Pid, MAddr, StreamPid, Path) ->
     gen_server:call(Pid, {accept_stream, MAddr, StreamPid, Path}).
@@ -159,16 +162,17 @@ handle_call(workers, _From, State=#state{workers=Workers}) ->
 handle_call(info, _From, State=#state{group_id=GroupID, handler=Handler, workers=Workers}) ->
     AddWorkerInfo = fun(#worker{pid=self}, Map) ->
                             maps:put(info, self, Map);
-                       (#worker{pid=Pid, ready=true}, Map) ->
-                            maps:put(info, libp2p_group_worker:info(Pid), Map);
-                       (#worker{ready=false}, Map)->
-                            Map
+                       (#worker{pid=Pid}, Map) ->
+                            maps:put(info, libp2p_group_worker:info(Pid), Map)
                     end,
-    WorkerInfos = lists:foldl(fun(WorkerInfo=#worker{index=Index, ready=Ready}, Acc) ->
+    MsgKeyInfo = fun(undefined) -> undefined;
+                    (MsgKey) -> base58:binary_to_base58(MsgKey)
+                 end,
+    WorkerInfos = lists:foldl(fun(WorkerInfo=#worker{index=Index, msg_key=MsgKey}, Acc) ->
                                       maps:put(Index,
                                                AddWorkerInfo(WorkerInfo,
                                                              #{ index => Index,
-                                                                ready => Ready}),
+                                                                msg_key => MsgKeyInfo(MsgKey)}),
                                                Acc)
                               end, #{}, Workers),
     GroupInfo = #{
@@ -199,36 +203,44 @@ handle_cast({handle_input, Msg}, State=#state{handler=Handler, handler_state=Han
         {NewHandlerState, stop, Reason} ->
             {stop, Reason, NewHandlerState}
         end;
-handle_cast({send_ready, Index, Ready}, State0=#state{self_index=_SelfIndex}) ->
+handle_cast({send_ready, Index, Ready}, State=#state{self_index=_SelfIndex}) ->
     %% Sent by group worker after it gets a stream set up (send just
     %% once per assigned stream). On normal cases use send_result as
     %% the place to send more messages.
     %% lager:debug("~p IS READY ~p TO SEND TO ~p", [SelfIndex, Ready, Index]),
-    case is_ready_worker(Index, Ready, State0) of
+    case is_ready_worker(Index, Ready, State) of
         false ->
-            State1 = ready_worker(Index, Ready, State0),
             case Ready of
                 true ->
-                    {noreply, dispatch_next_messages([Index], State1)};
+                    {noreply, dispatch_next_messages([Index], State)};
                 _ ->
-                    {noreply, State1}
+                    {noreply, State}
             end;
         _ ->
-            {noreply, State0}
+            {noreply, State}
     end;
-handle_cast({send_result, {Key, Index}, ok}, State=#state{self_index=_SelfIndex}) ->
+handle_cast({send_result, {_Key, _Index}, ok}, State=#state{self_index=_SelfIndex}) ->
     %% Sent by group worker. Since we use an ack_stream the message
-    %% was acknowledged. Delete the outbound message for the given
-    %% index
-    %% lager:debug("~p SEND OK TO ~p: ~p ", [SelfIndex, Index, base58:binary_to_base58(Key)]),
-    NewState = delete_message(Key, State),
-    {noreply, dispatch_next_messages([Index], ready_worker(Index, true, NewState))};
+    %% was sent async, and the ack response comes back through a
+    %% handle_ack cast.
+    {noreply, State};
 handle_cast({send_result, {_Key, Index}, _Error}, State=#state{self_index=_SelfIndex}) ->
     %% Sent by group worker on error. Instead of looking up the
     %% message by key again we locate the first message that needs to
     %% be sent and dispatch it.
     %% lager:debug("~p SEND ERROR TO ~p: ~p ERR: ~p ", [_SelfIndex, Index, base58:binary_to_base58(_Key), _Error]),
-    {noreply, dispatch_next_messages([Index], ready_worker(Index, true, State))};
+    {noreply, dispatch_next_messages([Index], ready_worker(Index, undefined, State))};
+handle_cast({handle_ack, Index}, State=#state{self_index=_SelfIndex}) ->
+    case lookup_worker(Index, State) of
+        #worker{msg_key=undefined} ->
+            lager:debug("Unexpected ack for ~p", [Index]),
+            State;
+        #worker{msg_key=MsgKey} ->
+            %% Delete the outbound message for the given index
+            NewState = delete_message(MsgKey, State),
+            {noreply, dispatch_next_messages([Index], ready_worker(Index, undefined, NewState))};
+        _ -> State
+    end;
 handle_cast(Msg, State) ->
     lager:warning("Unhandled cast: ~p", [Msg]),
     {noreply, State}.
@@ -238,7 +250,7 @@ handle_info({start_workers, Targets}, State=#state{group_id=GroupID, tid=TID}) -
     libp2p_swarm:add_stream_handler(libp2p_swarm:swarm(TID), ServerPath,
                                     {libp2p_ack_stream, server,[?MODULE, self()]}),
     {noreply, dispatch_inbound_messages(State#state{workers=start_workers(Targets, State)})};
-handle_info({handle_ack, Index}, State=#state{}) ->
+handle_info({send_ack, Index}, State=#state{}) ->
     %% lager:debug("RELCAST SERVER DISPATCHING ACK TO ~p", [Index]),
     {noreply, dispatch_ack(Index, State)};
 handle_info(Msg, State) ->
@@ -281,7 +293,7 @@ start_workers(TargetAddrs, #state{sup=Sup, group_id=GroupID,  tid=TID,
                       %% Dispatch a send_ready since there is no group
                       %% worker for self to do so
                       libp2p_group_server:send_ready(self(), SelfIndex, true),
-                      #worker{target=Addr, index=Index, pid=self, ready=false};
+                      #worker{target=Addr, index=Index, pid=self};
                   ({Index, Addr}) ->
                       ClientSpec = {Path, {libp2p_ack_stream, [Index, ?MODULE, self()]}},
                       {ok, WorkerPid} = supervisor:start_child(
@@ -293,18 +305,20 @@ start_workers(TargetAddrs, #state{sup=Sup, group_id=GroupID,  tid=TID,
                                            }),
                       %% sync on the mailbox having been flushed.
                       sys:get_status(WorkerPid),
-                      #worker{target=Addr, index=Index, pid=WorkerPid, ready=false}
+                      #worker{target=Addr, index=Index, pid=WorkerPid}
               end, lists:zip(lists:seq(1, length(TargetAddrs)), TargetAddrs)).
 
 is_ready_worker(Index, Ready, State=#state{}) ->
     case lookup_worker(Index, State) of
-        #worker{ready=Ready} -> Ready;
+        #worker{msg_key=undefined} when Ready == true -> true;
+        #worker{msg_key=MsgKey} when MsgKey /= undefined, Ready == false -> true;
         _ -> false
     end.
 
+-spec ready_worker(pos_integer(), msg_key() | undefined, #state{}) -> #state{}.
 ready_worker(Index, Ready, State=#state{}) ->
     case lookup_worker(Index, State) of
-        Worker=#worker{} -> update_worker(Worker#worker{ready=Ready}, State);
+        Worker=#worker{} -> update_worker(Worker#worker{msg_key=Ready}, State);
         false -> State
     end.
 
@@ -312,6 +326,7 @@ ready_worker(Index, Ready, State=#state{}) ->
 update_worker(Worker=#worker{index=Index}, State=#state{workers=Workers}) ->
     State#state{workers=lists:keystore(Index, #worker.index, Workers, Worker)}.
 
+-spec lookup_worker(pos_integer(), #state{}) -> #worker{} | false.
 lookup_worker(Index, State=#state{}) ->
     lookup_worker(Index, #worker.index, State).
 
@@ -355,7 +370,7 @@ dispatch_next_messages(Indexes, State=#state{store=Store}) ->
                         %% lager:debug("~p DISPATCHING NEXT TO ~p", [SelfIndex, Index]),
                         {ok, Msg} = bitcask:get(Store, Key),
                         case lookup_worker(Index, Acc) of
-                            #worker{pid=self, ready=true} ->
+                            #worker{pid=self, msg_key=undefined} ->
                                 %% Dispatch a message to self directly
                                 Parent = self(),
                                 %% lager:debug("~p DISPATCHING TO SELF: ~p",
@@ -364,12 +379,12 @@ dispatch_next_messages(Indexes, State=#state{store=Store}) ->
                                               Result = handle_data(Parent, Index, Msg),
                                               libp2p_group_server:send_result(Parent, {Key, Index}, Result)
                                       end),
-                                ready_worker(Index, false, Acc);
-                            #worker{index=Index, pid=Worker, ready=true} ->
+                                ready_worker(Index, Key, Acc);
+                            #worker{index=Index, pid=Worker, msg_key=undefined} ->
                                 %% lager:debug("~p DISPATCHING TO ~p: ~p",
                                 %%             [SelfIndex, Index, base58:binary_to_base58(Key)]),
                                 libp2p_group_worker:send(Worker, {Key, Index}, Msg),
-                                ready_worker(Index, false, Acc)
+                                ready_worker(Index, Key, Acc)
                         end;
                    ({_Index, []}, Acc) -> Acc
                 end, State, lookup_messages(?OUTBOUND, FilteredIndices, State)).
@@ -378,7 +393,7 @@ dispatch_next_messages(Indexes, State=#state{store=Store}) ->
 filter_ready_workers(Indexes, State=#state{}) ->
     lists:filter(fun(Index) ->
                          case lookup_worker(Index, State) of
-                             #worker{ready=true} -> true;
+                             #worker{msg_key=undefined} -> true;
                              _ -> false
                          end
                     end, Indexes).

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -340,7 +340,7 @@ is_ready_worker(Index, Ready, State=#state{}) ->
         _ -> false
     end.
 
--spec ready_worker(pos_integer(), msg_key() | undefined, #state{}) -> #state{}.
+-spec ready_worker(pos_integer(), msg_key() | undefined | false, #state{}) -> #state{}.
 ready_worker(Index, Ready, State=#state{}) ->
     case lookup_worker(Index, State) of
         Worker=#worker{} -> update_worker(Worker#worker{msg_key=Ready}, State);

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -75,13 +75,13 @@ init([Kind, ClientSpec, Server, TID]) ->
                             gen_statem:state_enter_result(request_target);
                     (gen_statem:event_type(), Msg :: term(), Data :: term()) ->
                             gen_statem:event_handler_result(atom()).
-request_target(enter, _, Data=#data{kind=Kind, server=Server}) ->
+request_target(enter, _, #data{kind=Kind, server=Server}) ->
     libp2p_group_server:request_target(Server, Kind, self()),
-    {next_state, request_target, Data, ?ASSIGN_RETRY};
+    {keep_state_and_data, ?ASSIGN_RETRY};
 request_target(timeout, _, #data{}) ->
     repeat_state_and_data;
 request_target(cast, {assign_target, undefined}, #data{}) ->
-    repeat_state_and_data;
+    {keep_state_and_data, ?ASSIGN_RETRY};
 request_target(cast, {assign_target, MAddr}, Data=#data{}) ->
     {next_state, connect, Data#data{target=MAddr}};
 request_target(cast, {send, Ref, _Bin}, #data{server=Server}) ->

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -4,7 +4,7 @@
 -behavior(libp2p_info).
 
 %% API
--export([start_link/4, assign_target/2, assign_stream/3, send/3, ack/1]).
+-export([start_link/4, assign_target/2, assign_stream/3, send/3, send_ack/1]).
 
 %% gen_statem callbacks
 -export([callback_mode/0, init/1, terminate/3]).
@@ -45,9 +45,10 @@ assign_stream(Pid, MAddr, Connection) ->
 send(Pid, Ref, Data) ->
     gen_statem:cast(Pid, {send, Ref, Data}).
 
--spec ack(pid()) -> ok.
-ack(Pid) ->
-    gen_statem:cast(Pid, ack).
+-spec send_ack(pid()) -> ok.
+send_ack(Pid) ->
+    Pid ! send_ack,
+    ok.
 
 %% libp2p_info
 info(Pid) ->
@@ -167,6 +168,9 @@ connect(info, {assign_session, SessionPid}, Data=#data{client_spec={Path, {M, A}
             {keep_state, connect_retry(Data#data{session_monitor=monitor_session(undefined, Data),
                                                  stream_monitor=monitor_stream(undefined, Data)})}
     end;
+connect(info, send_ack, #data{stream_monitor={_, StreamPid}}) ->
+    StreamPid ! send_ack,
+    keep_state_and_data;
 connect(cast, {assign_stream, MAddr, StreamPid},
         Data=#data{tid=TID, stream_monitor=StreamMonitor={_,_CurrentStreamPid}}) when StreamMonitor /= undefined  ->
     %% If send_pid known we have an existing stream. Do not replace.
@@ -198,9 +202,6 @@ connect(cast, {send, Ref, _Bin}, #data{server=Server, stream_monitor=undefined})
 connect(cast, {send, Ref, Bin}, #data{server=Server, stream_monitor={_, StreamPid}}) ->
     Result = libp2p_framed_stream:send(StreamPid, Bin),
     libp2p_group_server:send_result(Server, Ref, Result),
-    keep_state_and_data;
-connect(cast, ack, #data{stream_monitor={_, StreamPid}}) ->
-    gen_server:cast(StreamPid, ack),
     keep_state_and_data;
 connect(EventType, Msg, Data) ->
     handle_event(EventType, Msg, Data).

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -23,9 +23,15 @@ end_per_testcase(_, Config) ->
 ack_test(Config) ->
     Client = proplists:get_value(client, Config),
     libp2p_framed_stream:send(Client, <<"hello">>, 100),
+
     receive
         {handle_data, ack_server_ref, <<"hello">>} -> ok
-    after 100 -> erlang:exit(timeout)
+    after 1000 -> erlang:exit(timeout_data)
+    end,
+
+    receive
+        {handle_ack, ack_server_ref} -> ok
+    after 1000 -> erlang:exit(timeout_ack)
     end,
 
     ok.
@@ -39,5 +45,6 @@ handle_data(Pid, Ref, Bin) ->
     Pid ! {handle_data, Ref, Bin},
     ok.
 
-handle_ack(_Pid, _Ref) ->
+handle_ack(Pid, Ref) ->
+    Pid ! {handle_ack, Ref},
     ok.

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -1,20 +1,26 @@
 -module(ack_stream_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([accept_stream/4, handle_data/3, handle_ack/2]).
--export([ack_test/1]).
+-export([accept_stream/4, handle_data/3, handle_ack/3]).
+-export([ack_test/1, defer_test/1]).
 
 
 all() ->
-    [ack_test].
+    [ack_test,
+    defer_test].
 
-init_per_testcase(_, Config) ->
+setup_swarms(HandleDataResponse, Config) ->
     Swarms = [S1, S2] = test_util:setup_swarms(),
     libp2p_swarm:add_stream_handler(S2, "serve_ack_frame",
-                                    {libp2p_ack_stream, server, [?MODULE, self()]}),
+                                    {libp2p_ack_stream, server, [?MODULE, {self(), HandleDataResponse}]}),
     Connection = test_util:dial(S1, S2, "serve_ack_frame"),
-    {ok, Stream} = libp2p_ack_stream:client(Connection, [ack_client_ref, ?MODULE, self()]),
+    {ok, Stream} = libp2p_ack_stream:client(Connection, [client, ?MODULE, self()]),
     [{swarms, Swarms}, {client, Stream} | Config].
+
+init_per_testcase(ack_test, Config) ->
+    setup_swarms(ok, Config);
+init_per_testcase(defer_test, Config) ->
+    setup_swarms(defer, Config).
 
 end_per_testcase(_, Config) ->
     Swarms = proplists:get_value(swarms, Config),
@@ -22,29 +28,41 @@ end_per_testcase(_, Config) ->
 
 ack_test(Config) ->
     Client = proplists:get_value(client, Config),
-    libp2p_framed_stream:send(Client, <<"hello">>, 100),
+    ok = libp2p_framed_stream:send(Client, <<"hello">>, 100),
 
     receive
-        {handle_data, ack_server_ref, <<"hello">>} -> ok
+        {handle_data, {server, _}, <<"hello">>} -> ok
     after 1000 -> erlang:exit(timeout_data)
     end,
 
+    ok.
+
+defer_test(Config) ->
+    Client = proplists:get_value(client, Config),
+    defer = libp2p_framed_stream:send(Client, <<"hello">>, 100),
+
+    Server = receive
+                 {handle_data, {server, S}, <<"hello">>} -> S
+             after 1000 -> erlang:exit(timeout_data)
+             end,
+
+    libp2p_ack_stream:send_ack(Server),
+
     receive
-        {handle_ack, ack_server_ref} -> ok
+        {handle_ack, client, ok} -> ok
     after 1000 -> erlang:exit(timeout_ack)
     end,
 
     ok.
 
-accept_stream(Pid, _MAddr, StreamPid, Path) ->
+accept_stream({Pid, _}, _MAddr, StreamPid, Path) ->
     Pid ! {accept_stream, StreamPid, Path},
-    {ok, ack_server_ref}.
+    {ok, {server, self()}}.
 
-
-handle_data(Pid, Ref, Bin) ->
+handle_data({Pid, Response}, Ref, Bin) ->
     Pid ! {handle_data, Ref, Bin},
-    ok.
+    Response.
 
-handle_ack(Pid, Ref) ->
-    Pid ! {handle_ack, Ref},
+handle_ack(Pid, Ref, Ack) ->
+    Pid ! {handle_ack, Ref, Ack},
     ok.

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -1,7 +1,7 @@
 -module(ack_stream_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([accept_stream/4, handle_data/3]).
+-export([accept_stream/4, handle_data/3, handle_ack/2]).
 -export([ack_test/1]).
 
 
@@ -37,4 +37,7 @@ accept_stream(Pid, _MAddr, StreamPid, Path) ->
 
 handle_data(Pid, Ref, Bin) ->
     Pid ! {handle_data, Ref, Bin},
+    ok.
+
+handle_ack(_Pid, _Ref) ->
     ok.

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -140,7 +140,7 @@ defer_test(Config) ->
     libp2p_group_relcast:handle_input(G1, <<"defer">>),
 
     %% G2 should receive the message at least once from G1 even though it defers it
-    [{handle_msg, 1, <<"defer">>} | _] = receive_messages([]),
+    true = lists:member({handle_msg, 1, <<"defer">>}, receive_messages([])),
 
     %% Then we ack it by telling G2 to ack for G1
     libp2p_group_relcast:handle_ack(G2, 1),
@@ -149,7 +149,7 @@ defer_test(Config) ->
     libp2p_group_relcast:handle_input(G2, <<"defer2">>),
 
     %% Which G1 should see as a message from G2
-    [{handle_msg, 2, <<"defer2">>} | _] = receive_messages([]),
+    true = lists:member({handle_msg, 2, <<"defer2">>}, receive_messages([])),
 
     true = is_map(libp2p_group_relcast:info(G1)),
     ok.

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -143,7 +143,7 @@ defer_test(Config) ->
     true = lists:member({handle_msg, 1, <<"defer">>}, receive_messages([])),
 
     %% Then we ack it by telling G2 to ack for G1
-    libp2p_group_relcast:handle_ack(G2, 1),
+    libp2p_group_relcast:send_ack(G2, 1),
 
     %% Send a message from G2 to G1
     libp2p_group_relcast:handle_input(G2, <<"defer2">>),


### PR DESCRIPTION
This fixes most of the observer reliability issues when restarting nodes that are part of a reliable broadcast group. 