### PR TITLE
Tweak behaviour of swarm_dir to handle nested directories

### DIFF
--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -57,7 +57,7 @@ base_dir(TID) ->
 
 -spec swarm_dir(ets:tab(), [file:name_all()]) -> file:filename_all().
 swarm_dir(TID, Names) ->
-    FileName = filename:join(base_dir(TID), [libp2p_swarm:name(TID) | Names]),
+    FileName = filename:join([base_dir(TID), libp2p_swarm:name(TID) | Names]),
     ok = filelib:ensure_dir(FileName),
     FileName.
 


### PR DESCRIPTION
I was just in the neighbourhood and this function looked wrong?