### PR TITLE
Add fallback clause to connections function

### DIFF
--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -116,7 +116,9 @@ connections(Kind, #state{workers=Workers}) ->
                     ({_, Pid, MAddr}, Acc) when Kind == all ->
                         [{MAddr, Pid} | Acc];
                     ({WorkerKind, Pid, MAddr}, Acc) when WorkerKind == Kind ->
-                        [{MAddr, Pid} | Acc]
+                        [{MAddr, Pid} | Acc];
+                   (_, Acc) ->
+                        Acc
                 end, [], Workers).
 
 assign_target(Kind, WorkerPid, TargetAddrs, State=#state{workers=Workers}) ->


### PR DESCRIPTION
This fixes an error triggered by adding something like

```erlang
{libp2p_gossip_group, [{seed_nodes, ["/ip4/34.222.64.221/tcp/2154"]}]}
```
to a swarm's options.