### PR TITLE
More stungun improvements:

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -5,7 +5,9 @@
 -behavior(libp2p_framed_stream).
 
 -callback handle_data(State::any(), Ref::any(), Msg::binary()) -> ok | defer | {error, term()}.
--callback accept_stream(State::any(), MAddr::string(), Stream::pid(), Path::string()) ->
+-callback accept_stream(State::any(),
+                        Connection::libp2p_connection:connection(),
+                        Stream::pid(), Path::string()) ->
     {ok, Ref::any()} | {error, term()}.
 -callback handle_ack(State::any(), Ref::any(), Ack::ok | defer) -> ok.
 
@@ -40,8 +42,7 @@ server(Connection, Path, _TID, Args) ->
     libp2p_framed_stream:server(?MODULE, Connection, [Path | Args]).
 
 init(server, Connection, [Path, AckModule, AckState]) ->
-    {_, RemoteAddr} = libp2p_connection:addr_info(Connection),
-    case AckModule:accept_stream(AckState, RemoteAddr, self(), Path) of
+    case AckModule:accept_stream(AckState, Connection, self(), Path) of
         {ok, AckRef} ->
             {ok, #state{connection=Connection,
                         ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}};

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -133,7 +133,7 @@ start_client_session(TID, Addr, Connection, IdentifyHandler) ->
             SessionSup = libp2p_swarm_session_sup:sup(TID),
             {ok, SessionPid} = supervisor:start_child(SessionSup, ChildSpec),
             case libp2p_connection:controlling_process(Connection, SessionPid) of
-                ok ->
+                {ok, _} ->
                     libp2p_config:insert_session(TID, Addr, SessionPid),
                     libp2p_swarm:register_session(libp2p_swarm:swarm(TID), SessionPid),
                     libp2p_identify:spawn_identify(SessionPid, IdentifyHandler, client),

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -226,24 +226,41 @@ handle_cast(Msg, State) ->
 handle_info(Msg={identify, _Kind, Session, Identify}, State=#state{tid=TID}) ->
     %% Forward on to swarm server for initial registration
     libp2p_swarm_sup:server(TID) ! Msg,
-    {_, PeerAddr} = libp2p_session:addr_info(Session),
-    ObservedAddr = libp2p_identify:observed_addr(Identify),
-    {noreply, record_observed_addr(PeerAddr, ObservedAddr, State)};
-handle_info(stungun_retry, State=#state{observed_addrs=Addrs, tid=TID, stun_txns=StunTxns}) ->
-    {PeerPath, TxnID} = libp2p_stream_stungun:mk_stun_txn(),
-    %% choose a random connected peer to do stungun with
+    {LocalAddr, _PeerAddr} = libp2p_session:addr_info(Session),
+    RemoteP2PAddr = libp2p_crypto:address_to_p2p(libp2p_identify:address(Identify)),
     {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:address(TID)),
-    MyConnectedPeers = [libp2p_crypto:address_to_p2p(P) || P <- libp2p_peer:connected_peers(MyPeer)],
-    PeerAddr = lists:nth(rand:uniform(length(MyConnectedPeers)), MyConnectedPeers),
-    lager:info("retrying stungun with peer ~p", [PeerAddr]),
-    case libp2p_stream_stungun:dial(TID, PeerAddr, PeerPath, TxnID, self()) of
-        {ok, StunPid} ->
-            ObservedAddr = most_observed_addr(Addrs),
-            %% TODO: Remove this once dial stops using start_link
-            unlink(StunPid),
-            erlang:send_after(60000, self(), {stungun_timeout, TxnID}),
-            {noreply, State#state{stun_txns=add_stun_txn(TxnID, ObservedAddr, StunTxns)}};
-        _ ->
+    ListenAddrs = libp2p_peer:listen_addrs(MyPeer),
+    lager:info("IDENTIFY ~p ~p ~p ~p ~p", [LocalAddr, _PeerAddr, RemoteP2PAddr, libp2p_identify:observed_addr(Identify), ListenAddrs]),
+    case lists:member(LocalAddr, ListenAddrs) of
+        true ->
+            ObservedAddr = libp2p_identify:observed_addr(Identify),
+            {noreply, record_observed_addr(RemoteP2PAddr, ObservedAddr, State)};
+        false ->
+            lager:info("identify response for socket with local address ~p is not a listen addr socket, ignoring", [LocalAddr]),
+            %% this is likely a discovery session we dialed with unique_port
+            %% we can't trust this for the purposes of the observed address
+            {noreply, State}
+    end;
+handle_info(stungun_retry, State=#state{observed_addrs=Addrs, tid=TID, stun_txns=StunTxns}) ->
+    case most_observed_addr(Addrs) of
+        {ok, ObservedAddr} ->
+            {PeerPath, TxnID} = libp2p_stream_stungun:mk_stun_txn(),
+            %% choose a random connected peer to do stungun with
+            {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:address(TID)),
+            MyConnectedPeers = [libp2p_crypto:address_to_p2p(P) || P <- libp2p_peer:connected_peers(MyPeer)],
+            PeerAddr = lists:nth(rand:uniform(length(MyConnectedPeers)), MyConnectedPeers),
+            lager:info("retrying stungun with peer ~p", [PeerAddr]),
+            case libp2p_stream_stungun:dial(TID, PeerAddr, PeerPath, TxnID, self()) of
+                {ok, StunPid} ->
+                    %% TODO: Remove this once dial stops using start_link
+                    unlink(StunPid),
+                    erlang:send_after(60000, self(), {stungun_timeout, TxnID}),
+                    {noreply, State#state{stun_txns=add_stun_txn(TxnID, ObservedAddr, StunTxns)}};
+                _ ->
+                    {noreply, State}
+            end;
+        error ->
+            %% we need at least 2 peers to agree on the observed address
             {noreply, State}
     end;
 handle_info({stungun_nat, TxnID, NatType}, State=#state{tid=TID, stun_txns=StunTxns}) ->
@@ -500,12 +517,20 @@ is_observed_addr(ObservedAddr, Addrs) ->
               false, Addrs).
 
 most_observed_addr(Addrs) ->
+    lager:info("observed addresses ~p", [Addrs]),
     {_, ObservedAddrs} = lists:unzip(sets:to_list(Addrs)),
     Counts = dict:to_list(lists:foldl(fun(A, D) ->
                                               dict:update_counter(A, 1, D)
                                       end, dict:new(), ObservedAddrs)),
-    [{MostObservedAddr, _} |_] = lists:reverse(lists:keysort(1, Counts)),
-    MostObservedAddr.
+    lager:info("most observed addresses ~p", [Counts]),
+    [{MostObservedAddr, Count} |_] = lists:reverse(lists:keysort(1, Counts)),
+    case Count >= 2 of
+        true ->
+            {ok, MostObservedAddr};
+        false ->
+            error
+    end.
+
 
 -spec record_observed_addr(string(), string(), #state{}) -> #state{}.
 record_observed_addr(PeerAddr, ObservedAddr, State=#state{tid=TID, observed_addrs=ObservedAddrs, stun_txns=StunTxns}) ->

--- a/src/libp2p_yamux_stream.erl
+++ b/src/libp2p_yamux_stream.erl
@@ -56,7 +56,8 @@
 -export([new_connection/1, open_stream/3, receive_stream/3, update_window/3, receive_data/2]).
 % libp2p_connection
 -export([close/1, close_state/1, send/3, recv/3, acknowledge/2,
-         fdset/1, fdclr/1, addr_info/1, controlling_process/2]).
+         fdset/1, fdclr/1, addr_info/1, controlling_process/2,
+         session/1]).
 %% libp2p_info
 -export([info/1]).
 
@@ -133,6 +134,9 @@ fdclr(Pid) ->
 
 addr_info(Pid) ->
     statem(Pid, addr_info).
+
+session(Pid) ->
+    statem(Pid, session).
 
 controlling_process(_Pid, _Owner) ->
     {error, unsupported}.
@@ -290,6 +294,9 @@ handle_event({call, From}, addr_info, _State, Data=#state{addr_info=undefined, s
     {keep_state, Data#state{addr_info=AddrInfo}, {reply, From, AddrInfo}};
 handle_event({call, From}, addr_info, _State, #state{addr_info=AddrInfo}) ->
     {keep_state_and_data, {reply, From, AddrInfo}};
+handle_event({call, From}, session, _State, #state{session=Session}) ->
+    {keep_state_and_data, {reply, From, {ok, Session}}};
+
 
 % Catch all
 %

--- a/src/relay/libp2p_stream_relay.erl
+++ b/src/relay/libp2p_stream_relay.erl
@@ -119,6 +119,8 @@ handle_info(client, {init_bridge_sc, BridgeSC}, State) ->
     Bridge = libp2p_relay_bridge:create_sc(Server, Client),
     EnvBridge = libp2p_relay_envelope:create(Bridge),
     {noreply, State, libp2p_relay_envelope:encode(EnvBridge)};
+handle_info(server, stop, State) ->
+    {stop, normal, State};
 handle_info(_Type, _Msg, State) ->
     lager:warning("~p got unknown info message ~p", [_Type, _Msg]),
     {noreply, State}.

--- a/src/relay/libp2p_stream_relay.erl
+++ b/src/relay/libp2p_stream_relay.erl
@@ -69,9 +69,7 @@ init(client, Conn, Args) ->
             {ok, {_Self, ServerAddress}} = libp2p_relay:p2p_circuit(CircuitAddress),
             self() ! {init_bridge_cr, ServerAddress}
     end,
-    TID = libp2p_swarm:tid(Swarm),
-    {_Local, Remote} = libp2p_connection:addr_info(Conn),
-    {ok, SessionPid} = libp2p_config:lookup_session(TID, Remote, []),
+    {ok, SessionPid} = libp2p_connection:session(Conn),
     {ok, #state{swarm=Swarm, sessionPid=SessionPid}}.
 
 handle_data(server, Bin, State) ->


### PR DESCRIPTION
* Don't use 'unique_port' sessions, they're too confusing
* Fix the verify protocol dial path
* Group observed addresses by peer's p2p address
* Explicitly require at least 2 address confirmations
* Even. More. Logging.

There's still a weird problem where dialing a framed stream on a peer returns 'timeout' (even though no timeout should occur).