### PR TITLE
Restart stateful transport modules if they exit abnormally

### DIFF
--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -163,14 +163,13 @@ add_transport_handler(TID, Transport) ->
         false ->
             TransportSup = libp2p_swarm_transport_sup:sup(TID),
             ChildSpec = #{ id => Transport,
-                           start => {Transport, start_link, [TID]},
-                           restart => temporary,
+                           start => {libp2p_transport, start_link, [Transport, TID]},
+                           restart => transient,
                            shutdown => 5000,
                            type => worker },
             case supervisor:start_child(TransportSup, ChildSpec) of
                 {error, Error} -> {error, Error};
-                {ok, TransportPid} ->
-                    libp2p_config:insert_transport(TID, Transport, TransportPid),
+                {ok, _TransportPid} ->
                     ok
             end
     end.

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -52,7 +52,7 @@ handle_info({identify, Kind, Session, Identify}, State=#state{tid=TID}) ->
     libp2p_config:insert_session(TID, libp2p_crypto:address_to_p2p(libp2p_identify:address(Identify)), Session),
     {noreply, State};
 handle_info({'DOWN', MonitorRef, process, Pid, _}, State=#state{tid=TID}) ->
-    NewState = remove_monitor(MonitorRef, Pid, State),
+    {_Kind, NewState} = remove_monitor(MonitorRef, Pid, State),
     PeerBook = libp2p_swarm:peerbook(TID),
     libp2p_peerbook:unregister_session(PeerBook, Pid),
     libp2p_config:remove_pid(TID, Pid),
@@ -103,7 +103,7 @@ add_monitor(Kind, Pid, State=#state{monitors=Monitors}) ->
 remove_monitor(MonitorRef, Pid, State=#state{tid=TID, monitors=Monitors}) ->
     case lists:keytake(Pid, 1, Monitors) of
         false -> State;
-        {value, {Pid, {MonitorRef, _Kind}}, NewMonitors} ->
+        {value, {Pid, {MonitorRef, Kind}}, NewMonitors} ->
             libp2p_config:remove_pid(TID, Pid),
-            State#state{monitors=NewMonitors}
+            {Kind, State#state{monitors=NewMonitors}}
     end.

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -243,7 +243,6 @@ handle_info(Msg={identify, _Kind, Session, Identify}, State=#state{tid=TID}) ->
     RemoteP2PAddr = libp2p_crypto:address_to_p2p(libp2p_identify:address(Identify)),
     {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:address(TID)),
     ListenAddrs = libp2p_peer:listen_addrs(MyPeer),
-    lager:info("IDENTIFY ~p ~p ~p ~p ~p", [LocalAddr, _PeerAddr, RemoteP2PAddr, libp2p_identify:observed_addr(Identify), ListenAddrs]),
     case lists:member(LocalAddr, ListenAddrs) of
         true ->
             ObservedAddr = libp2p_identify:observed_addr(Identify),
@@ -336,8 +335,9 @@ handle_info({record_listen_addr, InternalAddr, ExternalAddr}, State=#state{tid=T
         _ ->
             {noreply, State}
     end;
-handle_info(Msg, _State) ->
-    lager:warning("Unhandled message ~p", [Msg]).
+handle_info(Msg, State) ->
+    lager:warning("Unhandled message ~p", [Msg]),
+    {noreply, State}.
 
 terminate(_Reason, #state{}) ->
     ok.


### PR DESCRIPTION
Note that the installed listeners seem to survive the transport crashing, so this PR mostly focuses on cleanup/restart of the transport itself.