### PR TITLE
Madninja/handle bad header

### DIFF
--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -192,7 +192,7 @@ connect(cast, {assign_stream, Conn, StreamPid},
                 {ok, SessionPid} ->
                     {keep_state, Data#data{session_monitor=monitor_session(SessionPid, Data),
                                            stream_pid=assign_stream(StreamPid, Data)}};
-                {error, _} ->
+                undefined ->
                     libp2p_framed_stream:close(StreamPid),
                     keep_state_and_data
             end

--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -70,7 +70,7 @@ swarm_dir(TID, Names) ->
 %% Common pid CRUD
 %%
 
--spec insert_pid(ets:tab(), atom(), term(), pid()) -> true.
+-spec insert_pid(ets:tab(), atom(), term(), pid() | undefined) -> true.
 insert_pid(TID, Kind, Ref, Pid) ->
     ets:insert(TID, {{Kind, Ref}, Pid}).
 
@@ -110,7 +110,7 @@ lookup_handlers(TID, TableKey) ->
 transport() ->
     ?TRANSPORT.
 
--spec insert_transport(ets:tab(), atom(), pid()) -> true.
+-spec insert_transport(ets:tab(), atom(), pid() | undefined) -> true.
 insert_transport(TID, Module, Pid) ->
     insert_pid(TID, ?TRANSPORT, Module, Pid).
 

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -52,7 +52,7 @@ handle_info({identify, Kind, Session, Identify}, State=#state{tid=TID}) ->
     libp2p_config:insert_session(TID, libp2p_crypto:address_to_p2p(libp2p_identify:address(Identify)), Session),
     {noreply, State};
 handle_info({'DOWN', MonitorRef, process, Pid, _}, State=#state{tid=TID}) ->
-    {_Kind, NewState} = remove_monitor(MonitorRef, Pid, State),
+    NewState = remove_monitor(MonitorRef, Pid, State),
     PeerBook = libp2p_swarm:peerbook(TID),
     libp2p_peerbook:unregister_session(PeerBook, Pid),
     libp2p_config:remove_pid(TID, Pid),
@@ -103,7 +103,7 @@ add_monitor(Kind, Pid, State=#state{monitors=Monitors}) ->
 remove_monitor(MonitorRef, Pid, State=#state{tid=TID, monitors=Monitors}) ->
     case lists:keytake(Pid, 1, Monitors) of
         false -> State;
-        {value, {Pid, {MonitorRef, Kind}}, NewMonitors} ->
+        {value, {Pid, {MonitorRef, _}}, NewMonitors} ->
             libp2p_config:remove_pid(TID, Pid),
-            {Kind, State#state{monitors=NewMonitors}}
+            State#state{monitors=NewMonitors}
     end.

--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -250,7 +250,7 @@ decode_header(<<?VERSION:8/integer-unsigned,
                Flags:16/integer-unsigned-big,
                StreamID:32/integer-unsigned-big,
                Length:32/integer-unsigned-big>>) ->
-    #header{type=Type, flags=Flags, stream_id=StreamID, length=Length};
+    {ok, #header{type=Type, flags=Flags, stream_id=StreamID, length=Length}};
 decode_header(_) ->
     {error, bad_header}.
 

--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -241,16 +241,19 @@ fdclr(Connection) ->
 read_header(Connection) ->
     case libp2p_connection:recv(Connection, ?HEADER_SIZE) of
         {error, Error} -> {error, Error};
-        {ok, Bin}      -> {ok, decode_header(Bin)}
+        {ok, Bin}      -> decode_header(Bin)
     end.
 
--spec decode_header(binary()) -> header().
+-spec decode_header(binary()) -> {ok, header()} | {error, term()}.
 decode_header(<<?VERSION:8/integer-unsigned,
                Type:8/integer-unsigned,
                Flags:16/integer-unsigned-big,
                StreamID:32/integer-unsigned-big,
                Length:32/integer-unsigned-big>>) ->
-    #header{type=Type, flags=Flags, stream_id=StreamID, length=Length}.
+    #header{type=Type, flags=Flags, stream_id=StreamID, length=Length};
+decode_header(_) ->
+    {error, bad_header}.
+
 
 
 -spec encode_header(header()) -> binary().

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -68,7 +68,7 @@ basic(_Config) ->
         ,{libp2p_framed_stream, server, [libp2p_stream_proxy_test, self(), ServerSwarm]}
     ),
 
-    Opts = SwarmOpts ++ [{proxy, [{address, "localhost"}, {port, 8080}]}],
+    Opts = SwarmOpts ++ [{proxy, [{address, "localhost"}, {port, 18080}]}],
     {ok, ProxySwarm} = libp2p_swarm:start(proxy_basic_proxy, Opts),
     ok = libp2p_swarm:listen(ProxySwarm, "/ip4/0.0.0.0/tcp/0"),
     libp2p_swarm:add_stream_handler(
@@ -149,7 +149,7 @@ two_proxy(_Config) ->
         ,{libp2p_framed_stream, server, [libp2p_stream_proxy_test, self(), ServerSwarm]}
     ),
 
-    Opts = SwarmOpts ++ [{proxy, [{address, "localhost"}, {port, 8080}]}],
+    Opts = SwarmOpts ++ [{proxy, [{address, "localhost"}, {port, 18080}]}],
     {ok, ProxySwarm} = libp2p_swarm:start(proxy_two_proxy, Opts),
     ok = libp2p_swarm:listen(ProxySwarm, "/ip4/0.0.0.0/tcp/0"),
     libp2p_swarm:add_stream_handler(


### PR DESCRIPTION
* Adds an error response when a yamux session header can not be decoded, which causes the session to stop normally (after logging) instead of crashing
* Fix up dialyzer issues and proxy test. The dialyzer issue  in group_worker may affect group worker behavior for the better under error conditions @Vagabond 