### PR TITLE
Madninja/zombie sockety

### DIFF
--- a/src/libp2p_framed_stream.erl
+++ b/src/libp2p_framed_stream.erl
@@ -368,6 +368,8 @@ handle_send_result({stop, Reason, From, Reply}, ok, State=#state{}) ->
 handle_send_result({stop, Reason, From, Reply}, {error, closed}, State=#state{}) ->
     gen_server:reply(From, Reply),
     {stop, Reason, State};
+handle_send_result(_, {error, timeout}, State=#state{}) ->
+    {stop, normal, State};
 handle_send_result(_, {error, closed}, State=#state{}) ->
     {stop, normal, State};
 handle_send_result(_, {error, Error}, State=#state{})  ->

--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -215,12 +215,19 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 
-terminate(_Reason, #state{connection=undefined, send_pid=undefined}) ->
-    ok;
 terminate(Reason, #state{connection=Connection, send_pid=SendPid}) ->
-    fdclr(Connection),
-    erlang:exit(SendPid, Reason),
-    libp2p_connection:close(Connection).
+    case Connection of
+        undefined -> ok;
+        _ ->
+            fdclr(Connection),
+            libp2p_connection:close(Connection)
+    end,
+    case SendPid of
+        undefined -> ok;
+        _ -> erlang:exit(SendPid, Reason)
+    end.
+
+
 
 
 %%


### PR DESCRIPTION
This simplifies goaway handling to where only normal goaway responses are dealt with as yamux intended. As far as I can tell dealing with error kinds of goaway codes doesn't work out well at all. 

In addition we quiet the logs a bit more by trapping some more timeouts in streams and sessions