### PR TITLE
This attempts to offer a closing phase of a relcast_group.

### DIFF
--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -376,7 +376,7 @@ start_workers(TargetAddrs, #state{sup=Sup, group_id=GroupID, tid=TID, self_index
                                           #{ id => make_ref(),
                                              start => {libp2p_group_worker, start_link,
                                                        [Index, ClientSpec, self(), GroupID, TID]},
-                                             restart => permanent
+                                             restart => transient
                                            }),
                       %% sync on the mailbox having been flushed.
                       sys:get_status(WorkerPid),

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -313,8 +313,9 @@ handle_info({send_ack, Index}, State=#state{}) ->
     {noreply, dispatch_ack(Index, State)};
 handle_info(force_close, State=#state{}) ->
     %% The timeout after the handler returned close has fired. Shut
-    %% down the group.
-    {stop, normal, State};
+    %% down the group by exiting the supervisor.
+    exit(State#state.sup, normal),
+    {noreply, State};
 
 handle_info(Msg, State) ->
     lager:warning("Unhandled info: ~p", [Msg]),

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -314,7 +314,7 @@ handle_info({send_ack, Index}, State=#state{}) ->
 handle_info(force_close, State=#state{}) ->
     %% The timeout after the handler returned close has fired. Shut
     %% down the group by exiting the supervisor.
-    exit(State#state.sup, normal),
+    libp2p_swarm:remove_group(State#state.tid, State#state.group_id),
     {noreply, State};
 
 handle_info(Msg, State) ->

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -314,7 +314,9 @@ handle_info({send_ack, Index}, State=#state{}) ->
 handle_info(force_close, State=#state{}) ->
     %% The timeout after the handler returned close has fired. Shut
     %% down the group by exiting the supervisor.
-    libp2p_swarm:remove_group(State#state.tid, State#state.group_id),
+    spawn(fun() ->
+                  libp2p_swarm:remove_group(State#state.tid, State#state.group_id)
+          end),
     {noreply, State};
 
 handle_info(Msg, State) ->

--- a/src/group/libp2p_group_relcast_sup.erl
+++ b/src/group/libp2p_group_relcast_sup.erl
@@ -22,7 +22,8 @@ init([TID, GroupID, Args]) ->
             type => supervisor
           },
          #{ id => server,
-            start => {libp2p_group_relcast_server, start_link, [TID, GroupID, Args, self()]}
+            start => {libp2p_group_relcast_server, start_link, [TID, GroupID, Args, self()]},
+            restart => transient
           }
         ],
     {ok, {SupFlags, ChildSpecs}}.

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -206,6 +206,7 @@ closing(info, {'DOWN', _, process, _, _}, Data=#data{}) ->
     %% already in closing mode completed it's work successfully
     {keep_state, Data#data{connect_pid=undefined}};
 
+
 closing(EventType, Msg, Data) ->
     handle_event(EventType, Msg, Data).
 
@@ -284,6 +285,14 @@ handle_event({call, From}, info, Data=#data{kind=Kind, server=ServerPid, target=
             },
     {keep_state, Data, [{reply, From, Info}]};
 
+handle_event(enter, _, #data{})  ->
+    %% Ignore out of order enter events since we may already have
+    %% exited the original state.
+    keeps_state_and_data;
+handle_event(info, connect_retry, #data{}) ->
+    %% Ignore unhandled connect_retry events. The connect state
+    %% overrides this to deal with actual retries.
+    keeps_state_and_data;
 handle_event(EventType, Msg, #data{}) ->
     lager:warning("Unhandled event ~p: ~p", [EventType, Msg]),
     keep_state_and_data.

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -262,8 +262,6 @@ handle_event(info, send_ack, #data{stream_pid=undefined}) ->
 handle_event(info, send_ack, #data{stream_pid=StreamPid}) ->
     StreamPid ! send_ack,
     keep_state_and_data;
-handle_event(info, {'EXIT', _, normal}, #data{}) ->
-    keep_state_and_data;
 handle_event({call, From}, info, Data=#data{kind=Kind, server=ServerPid, target=Target,
                                             stream_pid=StreamPid,
                                             session_monitor=SessionMonitor}) ->
@@ -285,6 +283,7 @@ handle_event({call, From}, info, Data=#data{kind=Kind, server=ServerPid, target=
                  end
             },
     {keep_state, Data, [{reply, From, Info}]};
+
 handle_event(EventType, Msg, #data{}) ->
     lager:warning("Unhandled event ~p: ~p", [EventType, Msg]),
     keep_state_and_data.

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -325,7 +325,7 @@ add_group(TID, GroupID, Module, Args) ->
                            start => {Module, start_link, [TID, GroupID, Args]},
                            restart => transient,
                            shutdown => 5000,
-                           type => worker },
+                           type => supervisor },
             case supervisor:start_child(GroupSup, ChildSpec) of
                 {error, Error} -> {error, Error};
                 {ok, GroupPid} ->

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -9,7 +9,7 @@
          add_connection_handler/3,
          add_stream_handler/3, stream_handlers/1,
          register_session/2, register_listener/2,
-         add_group/4,
+         add_group/4, remove_group/2,
          group_agent/1]).
 
 -type swarm_opts() :: [swarm_opt()].
@@ -334,6 +334,14 @@ add_group(TID, GroupID, Module, Args) ->
             end
     end.
 
+-spec remove_group(pid() | ets:tab(), GroupID::string()) -> ok | {error, term()}.
+remove_group(Sup, GroupID) when is_pid(Sup) ->
+    remove_group(tid(Sup), GroupID);
+remove_group(TID, GroupID) ->
+    GroupSup = libp2p_swarm_group_sup:sup(TID),
+    _ = supervisor:terminate_child(GroupSup, GroupID),
+    _ = libp2p_config:remove_group(TID, GroupID),
+    ok.
 
 %% Session Agent
 %%

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -312,7 +312,8 @@ stream_handlers(TID) ->
 %% Group
 %%
 
--spec add_group(pid() | ets:tab(), GroupID::string(), Module::atom(), Args::[any()]) -> {ok, pid()} | {error, term()}.
+-spec add_group(pid() | ets:tab(), GroupID::string(), Module::atom(), Args::[any()])
+               -> {ok, pid()} | {error, term()}.
 add_group(Sup, GroupID, Module, Args) when is_pid(Sup) ->
     add_group(tid(Sup), GroupID, Module, Args);
 add_group(TID, GroupID, Module, Args) ->
@@ -322,7 +323,7 @@ add_group(TID, GroupID, Module, Args) ->
             GroupSup = libp2p_swarm_group_sup:sup(TID),
             ChildSpec = #{ id => GroupID,
                            start => {Module, start_link, [TID, GroupID, Args]},
-                           restart => temporary,
+                           restart => transient,
                            shutdown => 5000,
                            type => worker },
             case supervisor:start_child(GroupSup, ChildSpec) of

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -195,6 +195,8 @@ close_test(Config) ->
               not erlang:is_process_alive(G2)
       end),
 
+    false = libp2p_config:lookup_group(libp2p_swarm:tid(S2), "test"),
+
     ok.
 
 restart_test(_Config) ->

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -1,20 +1,27 @@
 -module(group_relcast_SUITE).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([unicast_test/1, multicast_test/1, defer_test/1, restart_test/1]).
+-export([unicast_test/1, multicast_test/1, defer_test/1, close_test/1, restart_test/1]).
 
 all() ->
     [ %% restart_test,
       unicast_test,
       multicast_test,
-      defer_test
+      defer_test,
+      close_test
     ].
 
 init_per_testcase(defer_test, Config) ->
-    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]}]),
+    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                       {libp2p_nat, [{nat, false}]}]),
+    [{swarms, Swarms} | Config];
+init_per_testcase(close_test, Config) ->
+    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                       {libp2p_nat, [{nat, false}]}]),
     [{swarms, Swarms} | Config];
 init_per_testcase(_, Config) ->
-    Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]}]),
+    Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                       {libp2p_nat, [{nat, false}]}]),
     [{swarms, Swarms} | Config].
 
 end_per_testcase(_, Config) ->
@@ -155,7 +162,40 @@ defer_test(Config) ->
     ok.
 
 
-    %% Then we ack
+close_test(Config) ->
+    Swarms = [S1, S2] = proplists:get_value(swarms, Config),
+
+    test_util:connect_swarms(S1, S2),
+
+    await_peerbooks(Swarms),
+
+    Members = [libp2p_swarm:address(S) || S <- Swarms],
+
+    %% G1 takes input and broadcasts
+    G1Args = [relcast_handler, [Members, input_multicast(), undefined]],
+    {ok, G1} = libp2p_swarm:add_group(S1, "test", libp2p_group_relcast, G1Args),
+
+    %% G2 handles a message by closing
+    G2Args = [relcast_handler, [Members, undefined, handle_msg({close, 5000})]],
+    {ok, G2} = libp2p_swarm:add_group(S2, "test", libp2p_group_relcast, G2Args),
+
+    libp2p_group_relcast:handle_input(G1, <<"multicast">>),
+
+    Messages = receive_messages([]),
+    %% Messages are delivered at least once
+    true = length(Messages) >= 1,
+
+    %% G2 hould have indicated close state. Kill the connection
+    %% between S1 and S2. S1 may reconnect to S2 but S2 should not
+    %% attempt to reconnect to S1.
+    test_util:disconnect_swarms(S1, S2),
+
+    test_util:wait_until(
+      fun() ->
+              not erlang:is_process_alive(G2)
+      end),
+
+    ok.
 
 restart_test(_Config) ->
     %% Restarting a relcast group should resend outbound messages that

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -1,7 +1,7 @@
 -module(test_util).
 
 -export([setup/0, setup_swarms/0, setup_swarms/2, teardown_swarms/1,
-         connect_swarms/2,
+         connect_swarms/2, disconnect_swarms/2,
          wait_until/1, wait_until/3, rm_rf/1, dial/3, dial_framed_stream/5, nonl/1]).
 
 setup() ->
@@ -41,6 +41,15 @@ connect_swarms(Source, Target) ->
     [TargetAddr | _] = libp2p_swarm:listen_addrs(Target),
     {ok, Session} = libp2p_swarm:connect(Source, TargetAddr),
     Session.
+
+disconnect_swarms(Source, Target) ->
+    [TargetAddr | _] = libp2p_swarm:listen_addrs(Target),
+    case libp2p_config:lookup_session(libp2p_swarm:tid(Source), TargetAddr) of
+        false -> ok;
+        {ok, Session} ->
+            libp2p_session:close(Session),
+            ok
+    end.
 
 wait_until(Fun) ->
     wait_until(Fun, 40, 100).


### PR DESCRIPTION
The handler for a relcast group can return {close, Timeout}. The
following behavior is epected:

* Stop queing inbound messages
* Stop dialing to maintain outbound connections
* Exit the group after some timeout or after all outbound messages are acked