### PR TITLE
Switch peerbook to use rocksdb

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,9 +21,9 @@
     {cuttlefish, ".*", {git, "https://github.com/helium/cuttlefish", {branch, "develop"}}},
     {inet_ext, ".*", {git, "https://github.com/benoitc/inet_ext", {branch, "master"}}},
     {inert, ".*", {git, "https://github.com/msantos/inert", {branch, "master"}}},
-    {bitcask, ".*", {git, "https://github.com/helium/bitcask", {branch, "modernize"}}},
     {splicer, ".*", {git, "https://github.com/helium/erlang-splicer.git", {branch, "master"}}},
-    {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "master"}}}
+    {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "master"}}},
+    {rocksdb, ".*", {git, "https://gitlab.com/Vagabond1/erlang-rocksdb.git", {branch, "adt/open_with_ttl"}}}
 ]}.
 
 {erl_opts, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,6 @@
 {"1.1.0",
 [{<<"backoff">>,{pkg,<<"backoff">>,<<"1.1.6">>},0},
  {<<"base32">>,{pkg,<<"base32">>,<<"0.1.0">>},1},
- {<<"bitcask">>,
-  {git,"https://github.com/helium/bitcask",
-       {ref,"d08cc8eedafefe4659b3be0ff8a256e70b72a6ec"}},
-  0},
  {<<"cuttlefish">>,
   {git,"https://github.com/helium/cuttlefish",
        {ref,"8672838e8f4ef61602aee6e4ff97ec9be54031dc"}},
@@ -37,13 +33,15 @@
   {git,"https://github.com/helium/relcast.git",
        {ref,"fbf09ad57f2be0062cfaae8087fc3073245a4b2b"}},
   0},
- {<<"rocksdb">>,{pkg,<<"rocksdb">>,<<"0.23.3">>},1},
+ {<<"rocksdb">>,
+  {git,"https://gitlab.com/Vagabond1/erlang-rocksdb.git",
+       {ref,"e74d055756addd675ac83f6981c83c02974a6959"}},
+  0},
  {<<"small_ints">>,{pkg,<<"small_ints">>,<<"0.1.0">>},1},
  {<<"splicer">>,
   {git,"https://github.com/helium/erlang-splicer.git",
        {ref,"3a2efb988162fd6ab400ad4183ddc4eac6e6b6e4"}},
-  0},
- {<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.0">>},1}]}.
+  0}]}.
 [
 {pkg_hash,[
  {<<"backoff">>, <<"83B72ED2108BA1EE8F7D1C22E0B4A00CFE3593A67DBC792799E8CCE9F42F796B">>},
@@ -60,7 +58,5 @@
  {<<"nat">>, <<"8E6A86D5A4419CBCE4C6E6A48EA77A106CE2598A04CDC5820D2840E9DBDFF04E">>},
  {<<"ranch">>, <<"F04166F456790FEE2AC1AA05A02745CC75783C2BFB26D39FAF6AEFC9A3D3A58A">>},
  {<<"rand_compat">>, <<"011646BC1F0B0C432FE101B816F25B9BBB74A085713CEE1DAFD2D62E9415EAD3">>},
- {<<"rocksdb">>, <<"1E088C3870265D4C037C4CA274C4153DAE739CE48D3C6536230C6B22226FF44E">>},
- {<<"small_ints">>, <<"82A824C8794A2DDC73CB5CD00EAD11331DB296521AD16A619C13D668572B868A">>},
- {<<"stacktrace_compat">>, <<"78E13E0747FABC71DC725A49A4CBDDE54CEC1E9ED13BD80C1D35AC37182E1FA0">>}]}
+ {<<"small_ints">>, <<"82A824C8794A2DDC73CB5CD00EAD11331DB296521AD16A619C13D668572B868A">>}]}
 ].

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -1,7 +1,5 @@
 -module(libp2p_group_relcast_server).
 
--include_lib("bitcask/include/bitcask.hrl").
-
 -behavior(gen_server).
 -behavior(libp2p_ack_stream).
 -behavior(libp2p_info).

--- a/src/libp2p.app.src
+++ b/src/libp2p.app.src
@@ -28,7 +28,6 @@
                   nat,
                   inet_ext,
                   ecc_compact,
-                  bitcask,
                   splicer,
                   backoff,
                   relcast


### PR DESCRIPTION
Note that this uses a special branch of rocksdb that implements the TTL feature. We can switch back to the upstream package once this is merged upstream.