### PR TITLE
Madninja/many sender spawns

### DIFF
--- a/src/libp2p_yamux_stream.erl
+++ b/src/libp2p_yamux_stream.erl
@@ -285,11 +285,11 @@ handle_event({call, From}, close_state, _, #state{close_state=CloseState}) ->
 
 % Info
 %
-handle_event(info, {'EXIT', From, Reason}, _State, #state{}) when Reason /= normal ->
-    lager:warning("Multistream server ~p exited with reason ~p", [From, Reason]),
-    keep_state_and_data;
-handle_event(info, {'EXIT', _, _}, _State, #state{})  ->
-    keep_state_and_data;
+handle_event(info, {'EXIT', Pid, normal}, _State, Data=#state{handler=Pid})  ->
+    {stop, normal, Data};
+handle_event(info, {'EXIT', Pid, Reason}, _State, Data=#state{handler=Pid}) ->
+    lager:warning("Multistream server ~p exited with reason ~p", [Pid, Reason]),
+    {stop, normal, Data};
 handle_event({call, From}, addr_info, _State, Data=#state{addr_info=undefined, session=Session}) ->
     AddrInfo = libp2p_session:addr_info(Session),
     {keep_state, Data#state{addr_info=AddrInfo}, {reply, From, AddrInfo}};


### PR DESCRIPTION
* Fixes yamux_streams to stop when the attached handler process exits
* async_send processes monitor their parent and stop when the parent process goes down