### PR TITLE
Make relay behave better:

### DIFF
--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -399,5 +399,10 @@ group_create(SwarmName) ->
     Name.
 
 group_join(Group, Pid) ->
-    ok = pg2:join(Group, Pid),
-    ok.
+    %% only allow a pid to join once
+    case lists:member(Pid, pg2:get_members(Group)) of
+        false ->
+            ok = pg2:join(Group, Pid);
+        true ->
+            ok
+    end.


### PR DESCRIPTION
* Only get peerbook values once
* Don't allow duplicate peerbook subscriptions from one pid
* Merge payload of new_peer message with cached peer entries
* Only allow 'init_relay' if a relay is not already started;
  this helps prevent multiple relay addresses being negotiated