### PR TITLE
Madninja/worker connect retry

### DIFF
--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -417,7 +417,11 @@ start_connect_retry_timer(Data=#data{connect_retry_timer=CurrentTimer}) ->
     Data#data{connect_retry_timer=Timer, connect_retry_backoff=NewBackOff}.
 
 stop_connect_retry_timer(Data=#data{connect_retry_timer=undefined}) ->
-    Data;
+    %% If we don't have a time we can cancel we make up a ref so that
+    %% the next start_timer behaves as if the backoff needs to
+    %% happen. This is required at the targeting->connecting
+    %% transition where the timer is not initialized yet.
+    Data#data{connect_retry_timer=make_ref()};
 stop_connect_retry_timer(Data=#data{connect_retry_timer=Timer}) ->
     %% We do not clear the connect_retry_timer to get a future
     %% start_connect_retry_timer to continue with the backoff


### PR DESCRIPTION
Fix and vary the behavior on group_worker when a connection fails:

* dno't assume a connect backoff reset when the connection fails
* go back to targeting when the mac connect backoff is reached to request a better target