### PR TITLE
Replace inert with a pure-Erlang version to avoid socket stealing issues

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,6 @@
     {backoff, "1.1.6"},
     {cuttlefish, ".*", {git, "https://github.com/helium/cuttlefish", {branch, "develop"}}},
     {inet_ext, ".*", {git, "https://github.com/benoitc/inet_ext", {branch, "master"}}},
-    {inert, ".*", {git, "https://github.com/msantos/inert", {branch, "master"}}},
     {splicer, ".*", {git, "https://github.com/helium/erlang-splicer.git", {branch, "master"}}},
     {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "master"}}}
 ]}.

--- a/src/libp2p_swarm_sup.erl
+++ b/src/libp2p_swarm_sup.erl
@@ -25,7 +25,6 @@ start_link(Args) ->
     supervisor:start_link(?MODULE, Args).
 
 init([Name, Opts]) ->
-    inert:start(),
     TID = ets:new(Name, [public, ordered_set, {read_concurrency, true}]),
     ets:insert(TID, {?SUP, self()}),
     ets:insert(TID, {?NAME, Name}),


### PR DESCRIPTION
This is mainly an interim fix to remove inert while we re-work how connection/stream packets events are done.

Note that since we don't support TLS yet, the comment about TLS sockets is irrelevant.