### PR TITLE
Remove inert, attempt #2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,6 @@
     {backoff, "1.1.6"},
     {cuttlefish, ".*", {git, "https://github.com/helium/cuttlefish", {branch, "develop"}}},
     {inet_ext, ".*", {git, "https://github.com/benoitc/inet_ext", {branch, "master"}}},
-    {inert, ".*", {git, "https://github.com/msantos/inert", {branch, "master"}}},
     {splicer, ".*", {git, "https://github.com/helium/erlang-splicer.git", {branch, "master"}}},
     {relcast, ".*", {git, "https://github.com/helium/relcast.git", {branch, "master"}}}
 ]}.

--- a/src/libp2p_swarm_sup.erl
+++ b/src/libp2p_swarm_sup.erl
@@ -25,7 +25,6 @@ start_link(Args) ->
     supervisor:start_link(?MODULE, Args).
 
 init([Name, Opts]) ->
-    inert:start(),
     TID = ets:new(Name, [public, ordered_set, {read_concurrency, true}]),
     ets:insert(TID, {?SUP, self()}),
     ets:insert(TID, {?NAME, Name}),

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -165,6 +165,38 @@ close_state(#tcp_state{socket=Socket}) ->
 acknowledge(#tcp_state{}, Ref) ->
     ranch:accept_ack(Ref).
 
+fdset_loop(Socket, Parent, Count) ->
+    %% this may screw up TLS sockets...
+    Event = case gen_tcp:recv(Socket, 1, 1000) of
+                {ok, P} ->
+                    ok = gen_tcp:unrecv(Socket, P),
+                    true;
+                {error, timeout} ->
+                    %% timeouts are not an event, they're just a way to handle fdclrs
+                    false;
+                {error, _R} ->
+                    true
+            end,
+    receive {Ref, clear} ->
+                Parent ! {Ref, ok};
+            {Ref, fdset} ->
+                Parent ! {Ref, {error, already_fdset}}
+    after 0 ->
+              case Event of
+                  false ->
+                      %% resume waiting
+                      fdset_loop(Socket, Parent, Count);
+                  true ->
+                      Parent ! {inert_read, Count, Socket},
+                      receive {Ref, fdset} ->
+                                  Parent ! {Ref, ok},
+                                  fdset_loop(Socket, Parent, Count + 1);
+                              {Ref, clear} ->
+                                  Parent ! {Ref, ok}
+                      end
+              end
+    end.
+
 -spec fdset(tcp_state()) -> ok | {error, term()}.
 fdset(#tcp_state{socket=Socket}=State) ->
     %% XXX This is a temporary fix to remove inert while we rework connections to be
@@ -173,25 +205,21 @@ fdset(#tcp_state{socket=Socket}=State) ->
     case erlang:get(fdset_pid) of
         undefined ->
             Pid = spawn(fun() ->
-                                %% this may screw up TLS sockets...
-                                case gen_tcp:recv(Socket, 1) of
-                                    {ok, P} ->
-                                        gen_tcp:unrecv(Socket, P);
-                                    {error, _R} ->
-                                        ok
-                                end,
-                                receive clear ->
-                                            ok
-                                after 0 ->
-                                          Parent ! {inert_read, 1, Socket}
-                                end
+                                fdset_loop(Socket, Parent, 1)
                         end),
             erlang:put(fdset_pid, Pid),
             ok;
         Pid ->
             case is_process_alive(Pid) of
                 true ->
-                    {error, already_fdset};
+                    Ref = erlang:monitor(process, Pid),
+                    Pid ! {Ref, fdset},
+                    receive {Ref, Return} ->
+                                erlang:demonitor(Ref, [flush]),
+                                Return;
+                            {'DOWN', Ref, process, Pid, Reason} ->
+                                {error, Reason}
+                    end;
                 false ->
                     erlang:put(fdset_pid, undefined),
                     fdset(State)
@@ -210,18 +238,27 @@ fdclr(#tcp_state{socket=Socket}) ->
         Pid ->
             case is_process_alive(Pid) of
                 true ->
-                    Pid ! clear;
+                    Ref = erlang:monitor(process, Pid),
+                    Pid ! {Ref, clear},
+                    receive {Ref, Return} ->
+                                erlang:demonitor(Ref, [flush]),
+                                %% consume any messages of this form in the mailbox
+                                receive
+                                    {inert_read, _N, Socket} ->
+                                        ok
+                                after 0 ->
+                                          ok
+                                end,
+                                erlang:put(fdset_pid, undefined),
+                                Return;
+                            {'DOWN', Ref, process, Pid, Reason} ->
+                                erlang:put(fdset_pid, undefined),
+                                {error, Reason}
+                    end;
                 false ->
+                    erlang:put(fdset_pid, undefined),
                     ok
-            end,
-            erlang:put(fdset_pid, undefined)
-    end,
-    %% consume any messages of this form in the mailbox
-    receive
-        {inert_read, 1, Socket} ->
-            ok
-    after 0 ->
-              ok
+            end
     end.
 
 -spec addr_info(tcp_state()) -> {string(), string()}.


### PR DESCRIPTION
The first iteration of this was incomplete and fell over in real-world usage.

This rewrites the previous patch to handle many edge cases and has survived some real-world usage.