### PR TITLE
Detect network changes and update peerbook

### DIFF
--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -215,7 +215,6 @@ listen(TID, Addr) ->
                     case Transport:start_listener(TransportPid, ListenAddr) of
                         {ok, TransportAddrs, ListenPid} ->
                             lager:info("Started Listener on ~p", [TransportAddrs]),
-                            libp2p_config:insert_listener(TID, TransportAddrs, ListenPid),
                             register_listener(swarm(TID), ListenPid);
                         {error, Error={{shutdown, _}, _}} ->
                             % We don't log shutdown errors to avoid cluttering the logs


### PR DESCRIPTION
When we detect a new local sockname, check our listen addresses and
resolve them (epecially 0.0.0.0 and ::). If they have changed, remove
any old listeners and register the new ones. This should assist
deployments on flaky or failover networks in keeping their peerbook
current.