### PR TITLE
Attempt to only ACK relcast packets when necessary

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -8,10 +8,10 @@
 -callback accept_stream(State::any(),
                         Stream::pid(), Path::string()) ->
     {ok, Ref::any()} | {error, term()}.
--callback handle_ack(State::any(), Ref::any(), Seq::pos_integer(), Reset::boolean()) -> ok.
+-callback handle_ack(State::any(), Ref::any(), Seq::pos_integer(), Reset::boolean(), Range::boolean()) -> ok.
 
 %% API
--export([send_ack/3]).
+-export([send_ack/4]).
 %% libp2p_framed_stream
 -export([server/4, client/2, init/3, handle_data/3, handle_send/5, handle_info/3]).
 
@@ -26,9 +26,9 @@
 %% API
 %%
 
--spec send_ack(pid(), pos_integer(), boolean()) -> ok.
-send_ack(Pid, Seq, Reset) ->
-    Pid ! {send_ack, Seq, Reset},
+-spec send_ack(pid(), pos_integer(), boolean(), boolean()) -> ok.
+send_ack(Pid, Seq, Reset, Range) ->
+    Pid ! {send_ack, Seq, Reset, Range},
     ok.
 
 %% libp2p_framed_stream
@@ -53,23 +53,23 @@ init(client, Connection, [AckRef, AckModule, AckState]) ->
 
 handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}) ->
     case libp2p_ack_stream_pb:decode_msg(Data, libp2p_ack_frame_pb) of
-        #libp2p_ack_frame_pb{data=Bin, seq=Seq} when Bin /= <<>> ->
+        #libp2p_ack_frame_pb{data=Bin, seq=Seq, last_or_range_ack=Last} when Bin /= <<>> ->
             %% Inbound request to handle a message
-            AckModule:handle_data(AckState, AckRef, {Bin, Seq}),
+            AckModule:handle_data(AckState, AckRef, {Bin, Seq, Last == true}),
             {noreply, State};
-        #libp2p_ack_frame_pb{seq=Seq, reset=Reset} ->
+        #libp2p_ack_frame_pb{seq=Seq, reset=Reset, last_or_range_ack=Range} ->
             %% When we receive an ack response from the remote side we
             %% call the handler to deal with it.
-            AckModule:handle_ack(AckState, AckRef, Seq, Reset == true),
+            AckModule:handle_ack(AckState, AckRef, Seq, Reset == true, Range == true),
             {noreply, State};
         _Other ->
             {noreply, State}
     end.
 
-handle_send(_Kind, From, {Data, Seq}, Timeout, State=#state{}) ->
-    Msg = #libp2p_ack_frame_pb{data=Data, seq=Seq},
+handle_send(_Kind, From, {Data, Seq, Last}, Timeout, State=#state{}) ->
+    Msg = #libp2p_ack_frame_pb{data=Data, seq=Seq, last_or_range_ack=Last == true},
     {ok, {reply, From, pending}, libp2p_ack_stream_pb:encode_msg(Msg), Timeout, State#state{}}.
 
-handle_info(_Kind, {send_ack, Seq, Reset}, State=#state{}) ->
-    Msg = #libp2p_ack_frame_pb{seq=Seq, reset=Reset},
+handle_info(_Kind, {send_ack, Seq, Reset, Range}, State=#state{}) ->
+    Msg = #libp2p_ack_frame_pb{seq=Seq, reset=Reset, last_or_range_ack=Range},
     {noreply, State, libp2p_ack_stream_pb:encode_msg(Msg)}.

--- a/src/group/libp2p_ack_stream.proto
+++ b/src/group/libp2p_ack_stream.proto
@@ -4,4 +4,5 @@ message ack_frame {
     uint32 seq = 1;
     bytes data = 2;
     bool reset = 3;
+    bool last_or_range_ack = 4;
 }

--- a/src/group/libp2p_group_relcast.erl
+++ b/src/group/libp2p_group_relcast.erl
@@ -4,7 +4,7 @@
 
 -export_type([opt/0]).
 
--export([start_link/3, handle_input/2, send/2, send_ack/4,
+-export([start_link/3, handle_input/2, send/2, send_ack/5,
          info/1, queues/1]).
 
 -spec start_link(ets:tab(), GroupID::string(), Args::[any()])
@@ -17,9 +17,9 @@ handle_input(GroupPid, Msg) ->
     Server = libp2p_group_relcast_sup:server(GroupPid),
     libp2p_group_relcast_server:handle_input(Server, Msg).
 
-send_ack(GroupPid, Index, Seq, Reset) ->
+send_ack(GroupPid, Index, Seq, Reset, Range) ->
     Server = libp2p_group_relcast_sup:server(GroupPid),
-    libp2p_group_relcast_server:send_ack(Server, Index, Seq, Reset).
+    libp2p_group_relcast_server:send_ack(Server, Index, Seq, Reset, Range).
 
 %% @doc Send the given data to the member of the group. The
 %% implementation of the group determines the strategy used for

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -9,7 +9,7 @@
 %% API
 -export([start_link/4, start_link/5,
          assign_target/2, clear_target/1,
-         assign_stream/2, send/3, send_ack/3, close/1]).
+         assign_stream/2, send/3, send_ack/4, close/1]).
 
 %% gen_statem callbacks
 -export([callback_mode/0, init/1, terminate/3]).
@@ -92,9 +92,9 @@ close(Pid) ->
 
 %% @doc Used as a convenience for groups using libp2p_ack_stream, this
 %% function sends an ack to the worker's stream if connected.
--spec send_ack(pid(), pos_integer(), boolean()) -> ok.
-send_ack(Pid, Seq, Reset) ->
-    Pid ! {send_ack, Seq, Reset},
+-spec send_ack(pid(), pos_integer(), boolean(), boolean()) -> ok.
+send_ack(Pid, Seq, Reset, Range) ->
+    Pid ! {send_ack, Seq, Reset, Range},
     ok.
 
 %% libp2p_info
@@ -356,10 +356,10 @@ handle_event(cast, clear_target, #data{}) ->
 handle_event(cast, {assign_target, _Target}, #data{}) ->
     %% ignore (handled in all states but `closing')
     keep_state_and_data;
-handle_event(info, {send_ack, _Seq, _Reset}, #data{stream_pid=undefined}) ->
+handle_event(info, {send_ack, _Seq, _Reset, _Range}, #data{stream_pid=undefined}) ->
     keep_state_and_data;
-handle_event(info, {send_ack, Seq, Reset}, #data{stream_pid=StreamPid}) ->
-    StreamPid ! {send_ack, Seq, Reset},
+handle_event(info, {send_ack, Seq, Reset, Range}, #data{stream_pid=StreamPid}) ->
+    StreamPid ! {send_ack, Seq, Reset, Range},
     keep_state_and_data;
 handle_event(info, targeting_timeout, #data{}) ->
     %% ignore, handled only by `targeting'

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -4,7 +4,7 @@
 -behavior(libp2p_ack_stream).
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
--export([accept_stream/3, handle_data/3, handle_ack/4]).
+-export([accept_stream/3, handle_data/3, handle_ack/5]).
 -export([ack_test/1]).
 
 
@@ -28,16 +28,20 @@ end_per_testcase(_, Config) ->
 
 ack_test(Config) ->
     Client = proplists:get_value(client, Config),
-    pending = libp2p_framed_stream:send(Client, {<<"hello">>, 1}, 100),
+    pending = libp2p_framed_stream:send(Client, {<<"hello">>, 1, false}, 100),
 
     receive
-        {handle_data, {server, S}, <<"hello">>, Seq} -> libp2p_ack_stream:send_ack(S, Seq, false)
-    after 1000 -> erlang:exit(timeout_data)
+        {handle_data, {server, S}, <<"hello">>, Seq, false} -> libp2p_ack_stream:send_ack(S, Seq, false, false)
+    after 1000 ->
+              ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
+              erlang:exit(timeout_data)
     end,
 
     receive
-        {handle_ack, client, _Seq, false}-> ok
-    after 1000 -> erlang:exit(timeout_done)
+        {handle_ack, client, _Seq, false, false}-> ok
+    after 1000 ->
+              ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
+              erlang:exit(timeout_done)
     end,
 
     ok.
@@ -46,10 +50,10 @@ accept_stream({Pid, _}, StreamPid, Path) ->
     Pid ! {accept_stream, StreamPid, Path},
     {ok, {server, self()}}.
 
-handle_data({Pid, Response}, Ref, {Bin, Seq}) ->
-    Pid ! {handle_data, Ref, Bin, Seq},
+handle_data({Pid, Response}, Ref, {Bin, Seq, Last}) ->
+    Pid ! {handle_data, Ref, Bin, Seq, Last},
     Response.
 
-handle_ack(Pid, Ref, Seq, Reset) ->
-    Pid ! {handle_ack, Ref, Seq, Reset},
+handle_ack(Pid, Ref, Seq, Reset, Range) ->
+    Pid ! {handle_ack, Ref, Seq, Reset, Range},
     ok.

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -71,19 +71,25 @@ unicast_test(Config) ->
     %% Receive input message from G1 as handled by G1
     receive
         {handle_msg, 1, <<"unicast">>} -> ok
-    after 10000 -> error(timeout)
+    after 10000 ->
+              ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
+              error(timeout)
     end,
 
     %% Receive message from G1 as handled by G2
     receive
         {handle_msg, 1, <<"unicast1">>} -> ok
-    after 10000 -> error(timeout)
+    after 10000 ->
+              ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
+              error(timeout)
     end,
 
     %% Receive the message from G2 as handled by G3
     receive
         {handle_msg, 2, <<"unicast2">>} -> ok
-    after 10000 -> error(timeout)
+    after 10000 ->
+              ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
+              error(timeout)
     end,
     ok.
 


### PR DESCRIPTION
Attempt to use 'range acks' in relcast whenever possible. If we get a
data packet flagged 'last' from the sender, and we're able to deliver
it, we do a 'range' ack on that packet (but not any prior packets).

If we have a canary packet (defer queue full) we ack the last un-acked
packet for that worker and then single-ack all subsequent deliverable
packets until we're able to deliver the canary.