### PR TITLE
Find route to wallet from PPP addresses

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -98,7 +98,7 @@ match_addr(Addr, _TID) when is_list(Addr) ->
 
 -spec sort_addrs([string()]) -> [string()].
 sort_addrs(Addrs) ->
-    AddressesForDefaultRoutes = [ A || {ok, A} <- [inet_parse:address(inet_ext:get_internal_address(Addr)) || {_Interface, Addr} <- inet_ext:gateways(), Addr /= [], Addr /= undefined]],
+    AddressesForDefaultRoutes = [ A || {ok, A} <- [catch inet_parse:address(inet_ext:get_internal_address(Addr)) || {_Interface, Addr} <- inet_ext:gateways(), Addr /= [], Addr /= undefined]],
     sort_addrs(Addrs, AddressesForDefaultRoutes).
 
 -spec sort_addrs([string()], [inet:ip_address()]) -> [string()].


### PR DESCRIPTION
This PR should allow hotspots to assert location on hotspots that are connected via cellular.

The problem is that `inet_ext` is failing to parse the output from the `ip r` command as shown.

```
$ ip r
default dev ppp0 scope link 
10.59.4.14 dev ppp0 scope link 
169.254.0.0/16 dev ppp0 scope link src 169.254.172.203
```