### PR TITLE
Allow swarms to declare a network ID in their peerbook

### DIFF
--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -2,6 +2,7 @@
 
 -export([start/1, start/2, stop/1, is_stopping/1, swarm/1, tid/1,
          opts/1, name/1, pubkey_bin/1, p2p_address/1, keys/1,
+         set_network_id/2, get_network_id/1,
          store_peerbook/2, peerbook/1, peerbook_pid/1, cache/1, sessions/1,
          dial/3, dial/5, connect/2, connect/4,
          dial_framed_stream/5, dial_framed_stream/7,
@@ -126,6 +127,21 @@ keys(Sup) when is_pid(Sup) ->
 keys(TID) ->
     Server = libp2p_swarm_sup:server(TID),
     gen_server:call(Server, keys).
+
+-spec set_network_id(ets:tab() | pid(), binary()) -> ok.
+set_network_id(Sup, NetworkID) when is_pid(Sup) ->
+    set_network_id(tid(Sup), NetworkID);
+set_network_id(TID, NetworkID) ->
+    ets:insert(TID, {network_id, NetworkID}).
+
+-spec get_network_id(ets:tab() | pid()) -> binary() | undefined.
+get_network_id(Sup) when is_pid(Sup) ->
+    get_network_id(tid(Sup));
+get_network_id(TID) ->
+    case ets:lookup(TID, network_id) of
+        [{network_id, ID}] -> ID;
+        [] -> undefined
+    end.
 
 %% @doc get the peerbook db handle for a swarm
 -spec peerbook(ets:tab() | pid()) -> libp2p_peerbook:peerbook() | false.

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -2,7 +2,7 @@
 
 -export([start/1, start/2, stop/1, is_stopping/1, swarm/1, tid/1,
          opts/1, name/1, pubkey_bin/1, p2p_address/1, keys/1,
-         set_network_id/2, get_network_id/1,
+         network_id/2, network_id/1,
          store_peerbook/2, peerbook/1, peerbook_pid/1, cache/1, sessions/1,
          dial/3, dial/5, connect/2, connect/4,
          dial_framed_stream/5, dial_framed_stream/7,
@@ -128,16 +128,16 @@ keys(TID) ->
     Server = libp2p_swarm_sup:server(TID),
     gen_server:call(Server, keys).
 
--spec set_network_id(ets:tab() | pid(), binary()) -> ok.
-set_network_id(Sup, NetworkID) when is_pid(Sup) ->
-    set_network_id(tid(Sup), NetworkID);
-set_network_id(TID, NetworkID) ->
+-spec network_id(ets:tab() | pid(), binary()) -> ok.
+network_id(Sup, NetworkID) when is_pid(Sup) ->
+    network_id(tid(Sup), NetworkID);
+network_id(TID, NetworkID) ->
     ets:insert(TID, {network_id, NetworkID}).
 
--spec get_network_id(ets:tab() | pid()) -> binary() | undefined.
-get_network_id(Sup) when is_pid(Sup) ->
-    get_network_id(tid(Sup));
-get_network_id(TID) ->
+-spec network_id(ets:tab() | pid()) -> binary() | undefined.
+network_id(Sup) when is_pid(Sup) ->
+    network_id(tid(Sup));
+network_id(TID) ->
     case ets:lookup(TID, network_id) of
         [{network_id, ID}] -> ID;
         [] -> undefined

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -17,7 +17,7 @@
 
 -export([from_map/2, encode/1, decode/1, encode_list/1, decode_list/1, verify/1,
          pubkey_bin/1, listen_addrs/1, connected_peers/1, nat_type/1, timestamp/1,
-         supersedes/2, is_stale/2, is_similar/2, network_id/1]).
+         supersedes/2, is_stale/2, is_similar/2, network_id/1, network_id_allowable/2]).
 %% associations
 -export([associations/1, association_pubkey_bins/1, associations_set/4, associations_get/2, associations_put/4,
          is_association/3, association_pubkey_bin/1, association_signature/1,
@@ -245,6 +245,11 @@ network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id = <<>>}}) ->
     undefined;
 network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id=ID}}) ->
     ID.
+
+network_id_allowable(Peer, MyNetworkID) ->
+    network_id(Peer) == MyNetworkID
+    orelse libp2p_peer:network_id(Peer) == undefined
+    orelse MyNetworkID == undefined.
 
 %% @doc Returns whether a given peer is stale relative to a given
 %% stale delta time in milliseconds.

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -17,7 +17,7 @@
 
 -export([from_map/2, encode/1, decode/1, encode_list/1, decode_list/1, verify/1,
          pubkey_bin/1, listen_addrs/1, connected_peers/1, nat_type/1, timestamp/1,
-         supersedes/2, is_stale/2, is_similar/2]).
+         supersedes/2, is_stale/2, is_similar/2, network_id/1]).
 %% associations
 -export([associations/1, association_pubkey_bins/1, associations_set/4, associations_get/2, associations_put/4,
          is_association/3, association_pubkey_bin/1, association_signature/1,
@@ -45,6 +45,7 @@ from_map(Map, SigFun) ->
                            listen_addrs=[multiaddr:new(L) || L <- maps:get(listen_addrs, Map)],
                            connected = maps:get(connected, Map),
                            nat_type=maps:get(nat_type, Map),
+                           network_id=maps:get(network_id, Map, <<>>),
                            timestamp=Timestamp,
                            associations=Assocs
                           },
@@ -230,12 +231,20 @@ is_similar(Target=#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{}},
            Other=#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{}}) ->
     pubkey_bin(Target) == pubkey_bin(Other)
         andalso nat_type(Target) == nat_type(Other)
+        andalso network_id(Target) == network_id(Other)
         andalso sets:from_list(listen_addrs(Target)) == sets:from_list(listen_addrs(Other))
         andalso sets:from_list(connected_peers(Target)) == sets:from_list(connected_peers(Other))
         %% We only compare the {type, assoc_adddress} parts of an
         %% association as multiple signatures over the same value will
         %% differ
         andalso sets:from_list(association_pubkey_bins(Target)) == sets:from_list(association_pubkey_bins(Other)).
+
+%% @doc Returns the declared network id for the peer, if any
+-spec network_id(peer()) -> binary() | undefined.
+network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id = <<>>}}) ->
+    undefined;
+network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id=ID}}) ->
+    ID.
 
 %% @doc Returns whether a given peer is stale relative to a given
 %% stale delta time in milliseconds.

--- a/src/peerbook/libp2p_peer.proto
+++ b/src/peerbook/libp2p_peer.proto
@@ -15,6 +15,7 @@ message peer {
     nat_type nat_type = 4;
     int64 timestamp = 5;
     map<string, association_list> associations = 6;
+    bytes network_id = 7;
 }
 
 message association_list {

--- a/test/peerbook_SUITE.erl
+++ b/test/peerbook_SUITE.erl
@@ -5,7 +5,7 @@
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 -export([accessor_test/1, bad_peer_test/1, put_test/1, blacklist_test/1,
-         association_test/1, gossip_test/1, stale_test/1]).
+         association_test/1, gossip_test/1, network_id_gossip_test/1, stale_test/1]).
 
 all() ->
     [
@@ -13,6 +13,7 @@ all() ->
      bad_peer_test,
      put_test,
      gossip_test,
+     network_id_gossip_test,
      stale_test,
      blacklist_test,
      association_test
@@ -32,6 +33,15 @@ init_per_testcase(put_test, Config) ->
 init_per_testcase(gossip_test, Config) ->
     Swarms = test_util:setup_swarms(2, [{libp2p_group_gossip,
                                          [{peerbook_connections, 1}]
+                                        },
+                                        {libp2p_peerbook,
+                                         [{notify_time, 500},
+                                          {peer_time, 400}]
+                                        }]),
+    [{swarms, Swarms} | Config];
+init_per_testcase(network_id_gossip_test, Config) ->
+    Swarms = test_util:setup_swarms(3, [{libp2p_group_gossip,
+                                         [{peerbook_connections, 2}]
                                         },
                                         {libp2p_peerbook,
                                          [{notify_time, 500},
@@ -59,6 +69,9 @@ end_per_testcase(put_test, Config) ->
 end_per_testcase(gossip_test, Config) ->
     [S1, _S2] = proplists:get_value(swarms, Config),
     test_util:teardown_swarms([S1]);
+end_per_testcase(network_id_gossip_test, Config) ->
+    Swarms = proplists:get_value(swarms, Config),
+    test_util:teardown_swarms(Swarms);
 end_per_testcase(stale_test, Config) ->
     Swarms = proplists:get_value(swarms, Config),
     test_util:teardown_swarms(Swarms).
@@ -247,6 +260,75 @@ gossip_test(Config) ->
 
     ok.
 
+network_id_gossip_test(Config) ->
+    [S1, S2, S3] = proplists:get_value(swarms, Config),
+
+    libp2p_swarm:set_network_id(S1, <<"s1">>),
+    libp2p_swarm:set_network_id(S3, <<"s3">>),
+    <<"s1">> = libp2p_swarm:get_network_id(S1),
+    <<"s3">> = libp2p_swarm:get_network_id(S3),
+    S1PeerBook = libp2p_swarm:peerbook(S1),
+    S2PeerBook = libp2p_swarm:peerbook(S2),
+    S3PeerBook = libp2p_swarm:peerbook(S3),
+
+    %% force peerbook update
+    libp2p_peerbook:update_nat_type(S1PeerBook, none),
+    libp2p_peerbook:update_nat_type(S3PeerBook, none),
+
+    test_util:connect_swarms(S1, S2),
+    test_util:connect_swarms(S1, S3),
+    test_util:connect_swarms(S2, S3),
+
+    S1Addr = libp2p_swarm:pubkey_bin(S1),
+    S2Addr = libp2p_swarm:pubkey_bin(S2),
+    S3Addr = libp2p_swarm:pubkey_bin(S3),
+
+    ok = test_util:wait_until(fun() ->
+                                 {ok, S1Self} = libp2p_peerbook:get(S1PeerBook, S1Addr),
+                                 {ok, S2Self} = libp2p_peerbook:get(S2PeerBook, S2Addr),
+                                 {ok, S3Self} = libp2p_peerbook:get(S3PeerBook, S3Addr),
+                                 <<"s1">> == libp2p_peer:network_id(S1Self) andalso
+                                 undefined == libp2p_peer:network_id(S2Self) andalso
+                                 <<"s3">> == libp2p_peer:network_id(S3Self)
+                         end),
+
+    S1Group = libp2p_swarm:gossip_group(S1),
+    ok = test_util:wait_until(fun() ->
+                                 lists:member(libp2p_swarm:p2p_address(S2),
+                                              libp2p_group_gossip:connected_addrs(S1Group, all))
+                         end),
+    S2Group = libp2p_swarm:gossip_group(S2),
+    ok = test_util:wait_until(fun() ->
+                                 lists:member(libp2p_swarm:p2p_address(S1),
+                                              libp2p_group_gossip:connected_addrs(S2Group, all)) andalso
+                                 lists:member(libp2p_swarm:p2p_address(S3),
+                                              libp2p_group_gossip:connected_addrs(S2Group, all))
+                         end),
+
+    S3Group = libp2p_swarm:gossip_group(S3),
+    ok = test_util:wait_until(fun() ->
+                                 lists:member(libp2p_swarm:p2p_address(S2),
+                                              libp2p_group_gossip:connected_addrs(S3Group, all))
+                         end),
+
+    %% check that S1 can only see S2 because S3 has a different network ID
+    ok = test_util:wait_until(fun() ->
+                                      ok == element(1, libp2p_peerbook:get(S1PeerBook, S2Addr)) andalso
+                                      error == element(1, libp2p_peerbook:get(S1PeerBook, S3Addr))
+                              end),
+
+    %% check that S2 can see S1 and S3 because S2 has not set a network ID
+    ok = test_util:wait_until(fun() ->
+                                      ok == element(1, libp2p_peerbook:get(S2PeerBook, S1Addr)) andalso
+                                      ok == element(1, libp2p_peerbook:get(S2PeerBook, S3Addr))
+                              end, 60, 1000),
+
+    %% check that S3 can only see S2 because S1 has a different network ID
+    ok = test_util:wait_until(fun() ->
+                                      ok == element(1, libp2p_peerbook:get(S3PeerBook, S2Addr)) andalso
+                                      error == element(1, libp2p_peerbook:get(S3PeerBook, S1Addr))
+                              end),
+    ok.
 
 stale_test(Config) ->
     [S1] = proplists:get_value(swarms, Config),

--- a/test/peerbook_SUITE.erl
+++ b/test/peerbook_SUITE.erl
@@ -263,10 +263,10 @@ gossip_test(Config) ->
 network_id_gossip_test(Config) ->
     [S1, S2, S3] = proplists:get_value(swarms, Config),
 
-    libp2p_swarm:set_network_id(S1, <<"s1">>),
-    libp2p_swarm:set_network_id(S3, <<"s3">>),
-    <<"s1">> = libp2p_swarm:get_network_id(S1),
-    <<"s3">> = libp2p_swarm:get_network_id(S3),
+    libp2p_swarm:network_id(S1, <<"s1">>),
+    libp2p_swarm:network_id(S3, <<"s3">>),
+    <<"s1">> = libp2p_swarm:network_id(S1),
+    <<"s3">> = libp2p_swarm:network_id(S3),
     S1PeerBook = libp2p_swarm:peerbook(S1),
     S2PeerBook = libp2p_swarm:peerbook(S2),
     S3PeerBook = libp2p_swarm:peerbook(S3),


### PR DESCRIPTION
Network IDs are a way to prevent crosstalk between logically partitioned
libp2p networks. Swarms can declare their network ID (application
name/version, genesis block, whatever) and they will not see peer
entries from peers with a different network ID.

Swarms that do not declare a network ID can still be contacted and will
be allowed into the peerbook. Thus nodes implementing shared
infrastructure (eg. seed nodes) can be used for both sides of a logical
partition.