### PR TITLE
quieter libp2p + some elections-related cleanup

### DIFF
--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -290,14 +290,14 @@ handle_info(force_close, State=#state{}) ->
     spawn(fun() ->
                   libp2p_swarm:remove_group(State#state.tid, State#state.group_id)
           end),
-    {noreply, State};
+    {noreply, State#state{close_state=closing}};
 
 handle_info(Msg, State) ->
     lager:warning("Unhandled info: ~p", [Msg]),
     {noreply, State}.
 
 
-terminate(normal, #state{close_state=closing, store=Store, store_dir=StoreDir}) ->
+terminate(_, #state{close_state=closing, store=Store, store_dir=StoreDir}) ->
     relcast:stop(normal, Store),
     rm_rf(StoreDir);
 terminate(Reason, #state{store=Store}) ->

--- a/src/group/libp2p_group_relcast_sup.erl
+++ b/src/group/libp2p_group_relcast_sup.erl
@@ -29,11 +29,19 @@ init([TID, GroupID, Args]) ->
     {ok, {SupFlags, ChildSpecs}}.
 
 server(Sup) ->
-    Children = supervisor:which_children(Sup),
-    {?SERVER, Pid, _, _} = lists:keyfind(?SERVER, 1, Children),
-    Pid.
+    try supervisor:which_children(Sup) of
+        Children ->
+            {?SERVER, Pid, _, _} = lists:keyfind(?SERVER, 1, Children),
+            Pid
+    catch _:_ ->
+            {error, bad_sup}
+    end.
 
 workers(Sup) ->
-    Children = supervisor:which_children(Sup),
-    {?WORKERS, Pid, _, _} = lists:keyfind(?WORKERS, 1, Children),
-    Pid.
+    try supervisor:which_children(Sup) of
+        Children ->
+            {?WORKERS, Pid, _, _} = lists:keyfind(?WORKERS, 1, Children),
+            Pid
+    catch _:_ ->
+            {error, bad_sup}
+    end.

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -239,7 +239,7 @@ connecting(info, connect_retry_timeout, Data=#data{tid=TID,
             end),
             {keep_state, stop_connect_retry_timer(Data#data{connect_pid=Pid})};
         true ->
-            lager:warning("max connect retries exceeded, going back to targeting"),
+            lager:debug("max connect retries exceeded, going back to targeting"),
             {next_state, targeting, cancel_connect_retry_timer(Data), ?TRIGGER_TARGETING}
     end;
 connecting(EventType, Msg, Data) ->
@@ -261,7 +261,7 @@ connected(info, {'EXIT', StreamPid, Reason}, Data=#data{stream_pid=StreamPid, ta
     %% The stream we're using died. Let's go back to connecting, but
     %% do not trigger a connect retry right away, (re-)start the
     %% connect retry timer.
-    lager:warning("stream ~p with target ~p exited with reason ~p", [StreamPid, MAddr, Reason]),
+    lager:debug("stream ~p with target ~p exited with reason ~p", [StreamPid, MAddr, Reason]),
     {next_state, connecting,
      start_connect_retry_timer(Data#data{stream_pid=update_stream(undefined, Data)})};
 connected(cast, clear_target, Data=#data{}) ->
@@ -379,7 +379,7 @@ handle_event(info, {'EXIT', ConnectPid, _Reason}, Data=#data{connect_pid=Connect
 handle_event(info, {'EXIT', StreamPid, _Reason}, Data=#data{stream_pid=StreamPid}) ->
     %% The stream_pid copmleted, was killed, or crashed. Handled only
     %% by `connected'
-    lager:warning("stream pid ~p exited with reason ~p", [StreamPid, _Reason]),
+    lager:debug("stream pid ~p exited with reason ~p", [StreamPid, _Reason]),
     {keep_state, Data#data{stream_pid=update_stream(undefined, Data)}};
 handle_event({call, From}, info, Data=#data{target={Target,_}, stream_pid=StreamPid}) ->
     Info = #{

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -384,6 +384,7 @@ remove_group(Sup, GroupID) when is_pid(Sup) ->
 remove_group(TID, GroupID) ->
     GroupSup = libp2p_swarm_group_sup:sup(TID),
     _ = supervisor:terminate_child(GroupSup, GroupID),
+    _ = supervisor:delete_child(GroupSup, GroupID),
     _ = libp2p_config:remove_group(TID, GroupID),
     ok.
 


### PR DESCRIPTION
- moves some stuff to debug
- makes sure that elections don't cause infinite disk usage
- allows options to get to relcast