### PR TITLE
Madninja/gossip server load

### DIFF
--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -47,7 +47,7 @@ init(server, Connection, [HandlerModule, HandlerState]) ->
     case (catch HandlerModule:accept_stream(HandlerState, Session, self())) of
         ok -> {ok, State};
         {error, Reason} ->
-            lager:warning("Stopping on accept stream error: ~p", Reason),
+            lager:warning("Stopping on accept stream error: ~p", [Reason]),
             {stop, {error, Reason}, State};
         Exit={'EXIT', _} ->
             lager:warning("Stopping on accept_stream exit: ~s",

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -25,12 +25,20 @@
          workers=[] :: [#worker{}],
          handlers=#{} :: #{string() => libp2p_group_gossip:handler()},
          drop_timeout :: pos_integer(),
-         drop_timer :: reference()
+         drop_timer :: reference(),
+         peer_cache_timeout :: pos_integer(),
+         peer_cache_timer=make_ref() :: reference(),
+         peer_cache=[] :: [string()]
        }).
 
 -define(DEFAULT_PEERBOOK_CONNECTIONS, 5).
 -define(DEFAULT_MAX_INBOUND_CONNECTIONS, 10).
 -define(DEFAULT_DROP_TIMEOUT, 5 * 60 * 1000).
+%% Since fetching all known peers from the peerbook can take some
+%% time, we cache the addresses for 30 seconds before re-requesting,
+%% instead of fetching them every time, for every worker that comes in
+%% to ask.
+-define(DEFAULT_PEER_CACHE_TIMEOUT, 30 * 1000).
 -define(GROUP_ID, "gossip").
 -define(GROUP_PATH, "gossip/1.0.0").
 
@@ -60,14 +68,17 @@ init([Sup, TID]) ->
     PeerBookCount = get_opt(Opts, peerbook_connections, ?DEFAULT_PEERBOOK_CONNECTIONS),
     InboundCount = get_opt(Opts, inbound_connections, ?DEFAULT_MAX_INBOUND_CONNECTIONS),
     DropTimeOut = get_opt(Opts, drop_timeout, ?DEFAULT_DROP_TIMEOUT),
+    PeerCacheTimeOut = get_opt(Opts, peer_cache_timeout, ?DEFAULT_PEER_CACHE_TIMEOUT),
     SeedNodes = get_opt(Opts, seed_nodes, []),
+    self() ! peer_cache_timeout,
     self() ! {start_workers, PeerBookCount, length(SeedNodes)},
     {ok, update_metadata(#state{sup=Sup, tid=TID,
                                 seed_nodes=SeedNodes,
                                 max_inbound_connections=InboundCount,
                                 peerbook_connections=PeerBookCount,
                                 drop_timeout=DropTimeOut,
-                                drop_timer=schedule_drop_timer(DropTimeOut)})}.
+                                drop_timer=schedule_drop_timer(DropTimeOut),
+                                peer_cache_timeout=PeerCacheTimeOut})}.
 
 handle_call({accept_stream, _Session, _StreamPid}, _From, State=#state{workers=[]}) ->
     {reply, {error, not_ready}, State};
@@ -101,18 +112,7 @@ handle_cast({remove_handler, Key}, State=#state{handlers=Handlers}) ->
 
 handle_cast({request_target, inbound, WorkerPid}, State=#state{}) ->
     {noreply, stop_inbound_worker(WorkerPid, State)};
-handle_cast({request_target, Kind=peerbook, WorkerPid}, State=#state{tid=TID}) ->
-    %% Get all the keys to a peer. We catch any exceptions in talking
-    %% to peerbook here because during shutdown the peerbook may go
-    %% down before this server does which causes a very noisy crash
-    %% here.
-    PeerKeys = try
-                   libp2p_peerbook:keys(libp2p_swarm:peerbook(TID))
-               catch
-                   _:_ -> []
-               end,
-    PeerAddrs = [ libp2p_crypto:pubkey_bin_to_p2p(Key) || Key <- PeerKeys ],
-    %% Get currently connected addresses
+handle_cast({request_target, Kind=peerbook, WorkerPid}, State=#state{tid=TID, peer_cache=PeerAddrs}) ->
     {CurrentAddrs, _} = lists:unzip(connections(all, State)),
     LocalAddr = libp2p_swarm:p2p_address(TID),
     %% Exclude the local swarm address from the available addresses
@@ -120,7 +120,7 @@ handle_cast({request_target, Kind=peerbook, WorkerPid}, State=#state{tid=TID}) -
     %% Remove the current addrs from all possible peer addresses
     TargetAddrs = sets:to_list(sets:subtract(sets:from_list(PeerAddrs),
                                              sets:from_list(ExcludedAddrs))),
-    {noreply, assign_target(Kind, WorkerPid, TargetAddrs, State)};
+    {noreply, assign_target(Kind, WorkerPid, TargetAddrs, State#state{peer_cache=PeerAddrs})};
 handle_cast({request_target, Kind=seed, WorkerPid}, State=#state{tid=TID, seed_nodes=SeedAddrs}) ->
     {CurrentAddrs, _} = lists:unzip(connections(all, State)),
     LocalAddr = libp2p_swarm:p2p_address(TID),
@@ -189,6 +189,15 @@ handle_info(drop_timeout, State=#state{drop_timeout=DropTimeOut, drop_timer=Drop
             lager:debug("Timeout dropping 1 connection: ~p]", [Worker#worker.target]),
             {noreply, drop_target(Worker, State#state{drop_timer=schedule_drop_timer(DropTimeOut)})}
     end;
+handle_info(peer_cache_timeout, State=#state{tid=TID}) ->
+    PeerKeys = try
+                   libp2p_peerbook:keys(libp2p_swarm:peerbook(TID))
+               catch
+                   _:_ -> []
+               end,
+    PeerAddrs = [ libp2p_crypto:pubkey_bin_to_p2p(Key) || Key <- PeerKeys ],
+    Timer = erlang:send_after(State#state.peer_cache_timeout, self(), peer_cache_timeout),
+    {noreply, State#state{peer_cache=PeerAddrs, peer_cache_timer=Timer}};
 handle_info({handle_identify, {From, StreamPid}, {error, Error}}, State=#state{}) ->
     lager:notice("Failed to identify stream ~p: ~p", [StreamPid, Error]),
     gen_server:reply(From, {error, Error}),
@@ -234,6 +243,7 @@ terminate(_Reason, #state{tid=TID}) ->
 -spec schedule_drop_timer(pos_integer()) -> reference().
 schedule_drop_timer(DropTimeOut) ->
     erlang:send_after(DropTimeOut, self(), drop_timeout).
+
 
 -spec connections(libp2p_group_gossip:connection_kind() | all, #state{})
                  -> [{MAddr::string(), Pid::pid()}].

--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -36,7 +36,8 @@ init_per_testcase(seed_test, Config) ->
 init_per_testcase(_, Config) ->
     Swarms = test_util:setup_swarms(2, [
                                         {libp2p_group_gossip,
-                                         [{peerbook_connections, 1}]
+                                         [{peerbook_connections, 1},
+                                          {peer_cache_timeout, 100}]
                                         }]),
     [{swarms, Swarms} | Config].
 

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -22,14 +22,17 @@ all() ->
 
 init_per_testcase(defer_test, Config) ->
     Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                        {libp2p_group_gossip, [{peer_cache_timeout, 50}]},
                                         {libp2p_nat, [{enabled, false}]}]),
     [{swarms, Swarms} | Config];
 init_per_testcase(close_test, Config) ->
     Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                        {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
                                         {libp2p_nat, [{enabled, false}]}]),
     [{swarms, Swarms} | Config];
 init_per_testcase(_, Config) ->
     Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                        {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
                                         {libp2p_nat, [{enabled, false}]}]),
     [{swarms, Swarms} | Config].
 

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -57,7 +57,9 @@ end_per_testcase(_, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 basic(_Config) ->
-    SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
+    SwarmOpts = [{libp2p_nat, [{enabled, false}]},
+                 {libp2p_group_gossip, [{peer_cache_timeout, 100}]}
+                ],
     Version = "proxytest/1.0.0",
 
     {ok, ServerSwarm} = libp2p_swarm:start(proxy_basic_server, SwarmOpts),


### PR DESCRIPTION
This tries to fix two issues with the gossip_server:

1. Long peer address fetches from the peerbook. This could hold up the gossip_server for a while for every peerbook worker request for a target. We now cache the peer addresses for 30 seconds 

2. Terminating inbound workers. This was a bug where `supervisor:terminate_child` needed the child `id` not the pid to terminate it. We now store this in the worker state 