### PR TITLE
Fixes for relay/proxy

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -471,7 +471,8 @@ handle_info({stungun_nat, TxnID, NatType}, State=#state{tid=TID, stun_txns=StunT
             lager:debug("stungun detected NAT type ~p", [NatType]),
             case NatType of
                 none ->
-                    %% don't need to start relay here
+                    %% don't need to start relay here, stop any we already have
+                    libp2p_relay_server:stop(libp2p_swarm:swarm(TID)),
                     %% if we didn't have an external address originally, set the NAT type to 'static'
                     case State#state.negotiated_nat of
                         true ->

--- a/src/proxy/libp2p_proxy.erl
+++ b/src/proxy/libp2p_proxy.erl
@@ -61,7 +61,7 @@ dial_framed_stream(Swarm, Address, Args) ->
         ,Address
         ,?PROXY_VERSION
         ,libp2p_stream_proxy
-        ,Args
+        ,[{swarm, Swarm}|Args]
     ).
 
 %% ------------------------------------------------------------------

--- a/src/proxy/libp2p_transport_proxy.erl
+++ b/src/proxy/libp2p_transport_proxy.erl
@@ -44,34 +44,19 @@ connect(_Pid, MAddr, _Options, _Timeout, TID) ->
         {p2p_circuit, MAddr},
         {transport, self()},
         {id, ID}
-    ],
-    case libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_crypto:p2p_to_pubkey_bin(PAddress)) of
-        {error, _}=Error ->
-            Error;
-        {ok, PeerInfo} ->
-            HasRelayAddress = lists:any(
-                fun libp2p_relay:is_p2p_circuit/1,
-                libp2p_peer:cleared_listen_addrs(PeerInfo)
-            ),
-            case HasRelayAddress of
-                true ->
-                    lager:error("server ~p is not suitablw for proxy ", [PAddress]),
-                    {error, invalid_proxy};
-                false ->
-                    case libp2p_proxy:dial_framed_stream(Swarm, PAddress, Args) of
-                        {error, Reason} ->
-                            lager:error("failed to dial proxy server ~p ~p", [PAddress, Reason]),
-                            {error, fail_dial_proxy};
-                        {ok, _} ->
-                            receive
-                                {proxy_negotiated, Socket, MultiAddr} ->
-                                    Conn = libp2p_transport_tcp:new_connection(Socket, MultiAddr),
-                                    lager:info("proxy successful ~p", [Conn]),
-                                    libp2p_transport:start_client_session(TID, MAddr, Conn)
-                            after 8000 ->
-                                {error, timeout_relay_session}
-                            end
-                    end
+           ],
+    case libp2p_proxy:dial_framed_stream(Swarm, PAddress, Args) of
+        {error, Reason} ->
+            lager:error("failed to dial proxy server ~p ~p", [PAddress, Reason]),
+            {error, fail_dial_proxy};
+        {ok, _} ->
+            receive
+                {proxy_negotiated, Socket, MultiAddr} ->
+                    Conn = libp2p_transport_tcp:new_connection(Socket, MultiAddr),
+                    lager:info("proxy successful ~p", [Conn]),
+                    libp2p_transport:start_client_session(TID, MAddr, Conn)
+            after 8000 ->
+                      {error, timeout_relay_session}
             end
     end.
 


### PR DESCRIPTION
Prior to this change we have 2 issues:

* Nodes that did not need to advertise a relay listen address were doing so
* We refused to dial through a host with a relay address if that host itself was listed as a relay for another node

Fixing the first issue is not enough, as the second restriction is too broad. So we remove any relay stuff if our NAT type changes such that we know we don't need it AND we also add a `no_relay` dial flag so that if we're trying to dial a relay/proxy, we ignore the relay/proxy transport for dialing the intermediate host.

Given the internet's topology it's very unlikely we need to hop through multiple relays to get to a distant host, so this should solve most issues.