### PR TITLE
make idle_timeout configurable on a "connection" basis

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -49,6 +49,7 @@ init(server, Connection, [Path, AckModule, AckState]) ->
             {stop, {error, Reason}}
     end;
 init(client, Connection, [AckRef, AckModule, AckState]) ->
+    libp2p_connection:set_idle_timeout(Connection, infinity),
     {ok, #state{connection=Connection,
                 ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}}.
 

--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -42,6 +42,7 @@ server(Connection, Path, _TID, Args) ->
 init(server, Connection, [Path, AckModule, AckState]) ->
     case AckModule:accept_stream(AckState, self(), Path) of
         {ok, AckRef} ->
+            libp2p_connection:set_idle_timeout(Connection, infinity),
             {ok, #state{connection=Connection,
                         ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}};
         {error, Reason} ->

--- a/src/libp2p_connection.erl
+++ b/src/libp2p_connection.erl
@@ -14,7 +14,8 @@
          recv/1, recv/2, recv/3,
          acknowledge/2, fdset/1, socket/1, fdclr/1,
          addr_info/1, close/1, close_state/1,
-         controlling_process/2, session/1]).
+         controlling_process/2, session/1,
+         set_idle_timeout/2]).
 -export([mk_async_sender/2]).
 
 -callback acknowledge(any(), any()) -> ok.
@@ -26,6 +27,7 @@
 -callback fdclr(any()) -> ok.
 -callback addr_info(any()) -> {string(), string()}.
 -callback session(any()) -> {ok, pid()} | {error, term()}.
+-callback set_idle_timeout(any(), pos_integer() | infinity) -> ok | {error, term()}.
 -callback controlling_process(any(), pid()) ->  {ok, any()} | {error, closed | not_owner | atom()}.
 
 -define(RECV_TIMEOUT, 60000).
@@ -86,6 +88,10 @@ addr_info(#connection{module=Module, state=State}) ->
 -spec session(connection()) ->  {ok, pid()} | {error, term()}.
 session(#connection{module=Module, state=State}) ->
     Module:session(State).
+
+-spec set_idle_timeout(connection(), pos_integer() | infinity) -> ok | {error, term()}.
+set_idle_timeout(#connection{module=Module, state=State}, Timeout) ->
+    Module:set_idle_timeout(State, Timeout).
 
 -spec controlling_process(connection(), pid())-> {ok, connection()} | {error, closed | not_owner | atom()}.
 controlling_process(Conn=#connection{module=Module, state=State}, Pid) ->

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -43,7 +43,8 @@
 %% libp2p_connection
 -export([send/3, recv/3, acknowledge/2, addr_info/1,
          close/1, close_state/1, controlling_process/2,
-         session/1, fdset/1, socket/1, fdclr/1
+         session/1, fdset/1, socket/1, fdclr/1,
+         set_idle_timeout/2
         ]).
 
 %% for tcp sockets
@@ -284,6 +285,10 @@ session(#tcp_state{session=undefined}) ->
     {error, no_session};
 session(#tcp_state{session=Session}) ->
     {ok, Session}.
+
+-spec set_idle_timeout(tcp_state(), pos_integer() | infinity) -> ok | {error, term()}.
+set_idle_timeout(#tcp_state{}, _Timeout) ->
+    {error, not_implemented}.
 
 -spec controlling_process(tcp_state(), pid())
                          ->  {ok, tcp_state()} | {error, closed | not_owner | atom()}.

--- a/src/relay/libp2p_relay_server.erl
+++ b/src/relay/libp2p_relay_server.erl
@@ -112,8 +112,8 @@ handle_call(init_relay, _From, #state{started=false, swarm=Swarm}=State0) ->
     end;
 handle_call(init_relay, _From, State) ->
     {reply, {error, already_started}, State};
-handle_call(stop_relay, _From, #state{started=true, connection=Conn} = State) ->
-    libp2p_connection:close(Conn),
+handle_call(stop_relay, _From, #state{started=true, connection=Conn} = State) when Conn /= undefined ->
+    libp2p_framed_stream:close(Conn),
     {reply, ok, State#state{started=false, connection=undefined}};
 handle_call(stop_relay, _From, State) ->
     %% nothing to do as we're not running


### PR DESCRIPTION
This is only implemented for the yamux_stream connection
implementation right now