### PR TITLE
blow away the cache less often, don't validate peers on folds

### DIFF
--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -39,7 +39,7 @@
 %% time, we cache the addresses for a number of seconds before
 %% re-requesting, instead of fetching them every time, for every
 %% worker that comes in to ask.
--define(DEFAULT_PEER_CACHE_TIMEOUT, 10 * 1000).
+-define(DEFAULT_PEER_CACHE_TIMEOUT, 60 * 1000).
 -define(GROUP_ID, "gossip").
 -define(GROUP_PATH, "gossip/1.0.0").
 

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -16,7 +16,7 @@
 -type metadata() :: [{string(), binary()}].
 -export_type([peer/0, association/0, peer_map/0, nat_type/0]).
 
--export([from_map/2, encode/1, decode/1, encode_list/1, decode_list/1, verify/1,
+-export([from_map/2, encode/1, decode/1, decode_lite/1, encode_list/1, decode_list/1, verify/1,
          pubkey_bin/1, listen_addrs/1, connected_peers/1, nat_type/1, timestamp/1,
          supersedes/2, is_stale/2, is_similar/2, network_id/1, network_id_allowable/2]).
 %% associations
@@ -332,6 +332,10 @@ decode(Bin) ->
     verify(Msg),
     Msg.
 
+%% @doc Decodes a binary peer without verification, use with care.
+-spec decode_lite(binary()) -> peer().
+decode_lite(Bin) ->
+    libp2p_peer_pb:decode_msg(Bin, libp2p_signed_peer_pb).
 
 %% @doc Cryptographically verifies a given peer and it's
 %% associations. Returns true if the given peer can be verified or

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -16,7 +16,7 @@
 -type metadata() :: [{string(), binary()}].
 -export_type([peer/0, association/0, peer_map/0, nat_type/0]).
 
--export([from_map/2, encode/1, decode/1, decode_lite/1, encode_list/1, decode_list/1, verify/1,
+-export([from_map/2, encode/1, decode/1, decode_unsafe/1, encode_list/1, decode_list/1, verify/1,
          pubkey_bin/1, listen_addrs/1, connected_peers/1, nat_type/1, timestamp/1,
          supersedes/2, is_stale/2, is_similar/2, network_id/1, network_id_allowable/2]).
 %% associations
@@ -328,13 +328,13 @@ decode_list(Bin) ->
 %% @doc Decodes a given binary into a peer.
 -spec decode(binary()) -> peer().
 decode(Bin) ->
-    Msg = libp2p_peer_pb:decode_msg(Bin, libp2p_signed_peer_pb),
+    Msg = decode_unsafe(Bin),
     verify(Msg),
     Msg.
 
 %% @doc Decodes a binary peer without verification, use with care.
--spec decode_lite(binary()) -> peer().
-decode_lite(Bin) ->
+-spec decode_unsafe(binary()) -> peer().
+decode_unsafe(Bin) ->
     libp2p_peer_pb:decode_msg(Bin, libp2p_signed_peer_pb).
 
 %% @doc Cryptographically verifies a given peer and it's

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -414,11 +414,12 @@ fetch_peer(ID, Handle=#peerbook{stale_time=StaleTime}) ->
 
 fold_peers(Fun, Acc0, #peerbook{tid=TID, store=Store, stale_time=StaleTime}) ->
     {ok, Iterator} = rocksdb:iterator(Store, []),
+    NetworkID = libp2p_swarm:network_id(TID),
     fold(Iterator, rocksdb:iterator_move(Iterator, first),
          fun(Key, Bin, Acc) ->
-                 Peer = libp2p_peer:decode(Bin),
+                 Peer = libp2p_peer:decode_lite(Bin),
                  case libp2p_peer:is_stale(Peer, StaleTime)
-                      orelse not libp2p_peer:network_id_allowable(Peer, libp2p_swarm:network_id(TID)) of
+                     orelse not libp2p_peer:network_id_allowable(Peer, NetworkID) of
                      true -> Acc;
                      false -> Fun(Key, Peer, Acc)
                  end

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -417,7 +417,7 @@ fold_peers(Fun, Acc0, #peerbook{tid=TID, store=Store, stale_time=StaleTime}) ->
     NetworkID = libp2p_swarm:network_id(TID),
     fold(Iterator, rocksdb:iterator_move(Iterator, first),
          fun(Key, Bin, Acc) ->
-                 Peer = libp2p_peer:decode_lite(Bin),
+                 Peer = libp2p_peer:decode_unsafe(Bin),
                  case libp2p_peer:is_stale(Peer, StaleTime)
                      orelse not libp2p_peer:network_id_allowable(Peer, NetworkID) of
                      true -> Acc;


### PR DESCRIPTION
on the spots, we're seeing this take quite a long time even with smaller peerbooks.  I don't think we need to do full validation each time.