### PR TITLE
catch three common crashes and convert to normal stops or errors

### DIFF
--- a/src/libp2p_yamux_session.erl
+++ b/src/libp2p_yamux_session.erl
@@ -193,6 +193,9 @@ handle_info(timeout_idle, State=#state{}) ->
             {noreply, State#state{idle_timer=init_idle_timer(State#state.idle_timeout)}}
     end;
 
+handle_info({stop, {goaway, Code}}, State=#state{}) ->
+    lager:debug("got goaway with code ~p, stopping", [Code]),
+    {stop, normal, State};
 handle_info({stop, Reason}, State=#state{}) ->
     {stop, Reason, State};
 

--- a/src/proxy/libp2p_stream_proxy.erl
+++ b/src/proxy/libp2p_stream_proxy.erl
@@ -176,6 +176,7 @@ handle_client_data({dial_back, DialBack}, Env, State) ->
         {ok, Connection} ->
             {noreply, State#state{raw_connection=Connection}};
         {error, Reason} when Reason == timeout orelse
+                             Reason == etimedout orelse
                              Reason == tcp_closed ->
             {stop, normal, State};
         {error, Reason} ->


### PR DESCRIPTION
All three of these exits are really common, and don't really add any info, as they're just less common normal exit/stop pathways:

1:
```
2019-07-02 16:35:33.832 [warning] <0.7548.0>@libp2p_stream_proxy:dial_back:246 Failed to dial back to "/p2p/XXXXXXXXXXXXXXXXXB2koLro9LJesumSGpdNUBhWzBN" at "XXX.XXX.XXX.XXX" "48995": {error,etimedout}
2019-07-02 16:35:33.833 [error] <0.7548.0> gen_server <0.7548.0> terminated with reason: etimedout
2019-07-02 16:35:33.834 [error] <0.7548.0> CRASH REPORT Process <0.7548.0> with 0 neighbours exited with reason: etimedout in gen_server:handle_common_reply/8 line 751```
2:
```
2019-07-02 00:07:11.106 [warning] <0.25676.0>@libp2p_yamux_session:message_receive:512 Failed to read data for 1: closed
2019-07-02 00:07:11.107 [warning] <0.25676.0>@libp2p_yamux_session:goaway_cast:437 Session going away because of code: 2
2019-07-02 00:07:11.107 [error] <0.25676.0> gen_server <0.25676.0> terminated with reason: {goaway,2}
2019-07-02 00:07:11.113 [error] <0.25676.0> CRASH REPORT Process <0.25676.0> with 0 neighbours exited with reason: {goaway,2} in gen_s
erver:handle_common_reply/8 line 751
```
3: 
```
crash.log.0:    exception error: {{badmatch,{error,closed}},[{libp2p_framed_stream,verify_exchange,2,[{file,"libp2p_framed_stream.erl"},{line,422}]},{libp2p_framed_stream,handle_recv_result,2,[{file,"libp2p_framed_stream.erl"},{line,395}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,637}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,711}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]}
```