### PR TITLE
Fixes for cases where swarm has no initial connectivity

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -904,6 +904,7 @@ do_identify(Session, Identify, State=#state{tid=TID}) ->
                     [ libp2p_config:insert_listener(TID, LAs, P) || {LAs, P} <- NewListenAddrsWithPid],
                     PB = libp2p_swarm:peerbook(TID),
                     libp2p_peerbook:changed_listener(PB),
+                    libp2p_nat:maybe_spawn_discovery(self(), NewListenAddrs, TID),
                     {noreply, record_observed_addr(RemoteP2PAddr, ObservedAddr, State)};
                 false ->
                     lager:debug("identify response with local address ~p that is not a listen addr socket ~p, ignoring",


### PR DESCRIPTION
When the swarm comes up on a machine with no IPs, it can get in a state
where it takes a very long time (5 minutes) to detect an internet
connection because of the gossip targeting backoffs. This patch tweaks
the retargeting behaviour for seed connections and additionally will run
NAT discovery if an IP address change is detected; including going from
no IPs to any IPs.