### PR TITLE
Attempt to fix upnp nat rot again

### DIFF
--- a/src/nat/libp2p_nat.erl
+++ b/src/nat/libp2p_nat.erl
@@ -116,7 +116,7 @@ renew_port_mapping(InternalPort, ExternalPort) ->
             %% actually assigned, rather than the port the client originally wanted.
             add_port_mapping(InternalPort, ExternalPort);
         {ok, Context} ->
-            nat:delete_port_mapping(Context, tcp, InternalPort, ExternalPort),
+            %nat:delete_port_mapping(Context, tcp, InternalPort, ExternalPort),
             add_port_mapping(InternalPort, ExternalPort);
         no_nat ->
             {error, no_nat}


### PR DESCRIPTION
We're still seeing NAT rot on upnp connections. From googling around, other libraries don't delete the lease they just re-request it. Let's try that.