### PR TITLE
Decrease ack stream and relay stream timeouts, add relay ping/pong msg

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -23,7 +23,7 @@
           ack_ref :: any()
         }).
 
--define(ACK_STREAM_TIMEOUT, timer:minutes(30)).
+-define(ACK_STREAM_TIMEOUT, timer:minutes(5)).
 
 %% API
 %%

--- a/src/relay/libp2p_relay.proto
+++ b/src/relay/libp2p_relay.proto
@@ -31,6 +31,16 @@ message relay_bridge_sc {
     required string client = 2;
 }
 
+// Ping-Pong message to detect connection failure
+message relay_ping {
+    uint32 seq = 1;
+    enum Direction {
+        PING = 1;
+        PONG = 2;
+    }
+    Direction direction = 2;
+}
+
 message relay_envelope {
     oneof data {
         relay_req req = 1;
@@ -38,5 +48,6 @@ message relay_envelope {
         relay_bridge_cr bridge_cr = 3;
         relay_bridge_rs bridge_rs = 4;
         relay_bridge_sc bridge_sc = 5;
+        relay_ping ping = 6;
     }
 }

--- a/src/relay/libp2p_relay_envelope.erl
+++ b/src/relay/libp2p_relay_envelope.erl
@@ -50,7 +50,8 @@ encode(#libp2p_relay_envelope_pb{}=Env) ->
              | libp2p_relay_resp:relay_resp()
              | libp2p_relay_bridge:relay_bridge_cr()
              | libp2p_relay_bridge:relay_bridge_rs()
-             | libp2p_relay_bridge:relay_bridge_sc()) -> relay_envelope().
+             | libp2p_relay_bridge:relay_bridge_sc()
+             | libp2p_relay_bridge:relay_ping()) -> relay_envelope().
 create(#libp2p_relay_req_pb{}=Data) ->
     #libp2p_relay_envelope_pb{
         data={req, Data}
@@ -70,6 +71,10 @@ create(#libp2p_relay_bridge_rs_pb{}=Data) ->
 create(#libp2p_relay_bridge_sc_pb{}=Data) ->
     #libp2p_relay_envelope_pb{
         data={bridge_sc, Data}
+    };
+create(#libp2p_relay_ping_pb{}=Data) ->
+    #libp2p_relay_envelope_pb{
+        data={ping, Data}
     }.
 
 

--- a/src/relay/libp2p_stream_relay.erl
+++ b/src/relay/libp2p_stream_relay.erl
@@ -36,10 +36,22 @@
     swarm :: pid() | undefined,
     type = bridge :: bridge | client,
     relay_addr :: string() | undefined,
-    connection :: libp2p_connection:connection()
+    connection :: libp2p_connection:connection(),
+    ping_timer = make_ref() :: reference(),
+    ping_timeout_timer = make_ref() :: reference(),
+    ping_seq = 1 :: pos_integer()
 }).
 
--define(RELAY_TIMEOUT, timer:minutes(30)).
+-ifdef(TEST).
+-define(RELAY_TIMEOUT, timer:seconds(5)).
+-define(RELAY_PING_INTERVAL, timer:seconds(4)).
+-define(RELAY_PING_TIMEOUT, timer:seconds(1)).
+-else.
+-define(RELAY_TIMEOUT, timer:minutes(5)).
+-define(RELAY_PING_INTERVAL, timer:minutes(4)).
+-define(RELAY_PING_TIMEOUT, timer:minutes(1)).
+-endif.
+
 
 -type state() :: #state{}.
 
@@ -62,6 +74,7 @@ init(server, Conn, [_, _Pid, TID]=Args) ->
 init(client, Conn, Args) ->
     lager:debug("init relay client with ~p", [{Conn, Args}]),
     Swarm = proplists:get_value(swarm, Args),
+    Ref = erlang:send_after(?RELAY_PING_INTERVAL, self(), send_ping),
     case proplists:get_value(type, Args, undefined) of
         undefined ->
             self() ! init_relay;
@@ -71,7 +84,7 @@ init(client, Conn, Args) ->
             {ok, {_Self, ServerAddress}} = libp2p_relay:p2p_circuit(CircuitAddress),
             self() ! {init_bridge_cr, ServerAddress}
     end,
-    {ok, #state{swarm=Swarm, connection=Conn}}.
+    {ok, #state{swarm=Swarm, connection=Conn, ping_timer = Ref, ping_seq=1}}.
 
 handle_data(server, Bin, State) ->
     handle_server_data(Bin, State);
@@ -105,6 +118,14 @@ handle_info(client, {init_bridge_cr, Address}, #state{swarm=Swarm}=State) ->
             EnvBridge = libp2p_relay_envelope:create(Bridge),
             {noreply, State, libp2p_relay_envelope:encode(EnvBridge)}
     end;
+handle_info(client, ping_timeout, State) ->
+    {stop, normal, State};
+handle_info(client, send_ping, State = #state{ping_seq=Seq}) ->
+    erlang:cancel_timer(State#state.ping_timer),
+    Ping = libp2p_relay_ping:create_ping(Seq),
+    Env = libp2p_relay_envelope:create(Ping),
+    Ref = erlang:send_after(?RELAY_PING_TIMEOUT, self(), ping_timeout),
+    {noreply, State#state{ping_timeout_timer=Ref}, libp2p_relay_envelope:encode(Env)};
 % Bridge Step 3: The relay server R (stream to Server) receives a bridge request
 % and transfers it to Server.
 handle_info(server, {bridge_cr, BridgeCR}, State) ->
@@ -178,6 +199,10 @@ handle_server_data({bridge_sc, Bridge}, _Env,#state{swarm=Swarm}=State) ->
     SessionPids = [Pid || {_, Pid} <- libp2p_swarm:sessions(Swarm)],
     catch libp2p_relay:reg_addr_sessions(Server) ! {sessions, SessionPids},
     {noreply, State};
+handle_server_data({ping, Ping}, _Env, State) ->
+    Pong = libp2p_relay_ping:create_pong(Ping),
+    Env = libp2p_relay_envelope:create(Pong),
+    {noreply, State, libp2p_relay_envelope:encode(Env)};
 handle_server_data(_Data, _Env, State) ->
     lager:warning("server unknown envelope ~p", [_Env]),
     {noreply, State}.
@@ -217,6 +242,15 @@ handle_client_data({bridge_rs, Bridge}, _Env, #state{swarm=Swarm}=State) ->
             lager:warning("failed to dial back client ~p", [_Reason])
     end,
     {noreply, State};
+handle_client_data({ping, Pong}, _Env, #state{ping_seq=Seq}=State) ->
+    case libp2p_relay_ping:seq(Pong) of
+        Seq ->
+            erlang:cancel_timer(State#state.ping_timeout_timer),
+            Ref = erlang:send_after(?RELAY_PING_INTERVAL, self(), send_ping),
+            {noreply, State#state{ping_seq=Seq+1, ping_timer=Ref}};
+        _ ->
+            {stop, normal, State}
+    end;
 handle_client_data(_Data, _Env, State) ->
     lager:warning("client unknown envelope ~p", [_Env]),
     {noreply, State}.

--- a/src/relay/libp2p_stream_relay.erl
+++ b/src/relay/libp2p_stream_relay.erl
@@ -248,7 +248,8 @@ handle_client_data({ping, Pong}, _Env, #state{ping_seq=Seq}=State) ->
             erlang:cancel_timer(State#state.ping_timeout_timer),
             Ref = erlang:send_after(?RELAY_PING_INTERVAL, self(), send_ping),
             {noreply, State#state{ping_seq=Seq+1, ping_timer=Ref}};
-        _ ->
+        OtherSeq ->
+            lager:warning("Relay ping sequence invariant violated: expected ~p got ~p", [Seq, OtherSeq]),
             {stop, normal, State}
     end;
 handle_client_data(_Data, _Env, State) ->


### PR DESCRIPTION
To ensure the relay stream is actually working, add a ping/pong message
to the relay stream to help detect dead relay streams so the client
knows to obtain a new one.