### PR TITLE
Madninja/session addr info

### DIFF
--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -272,8 +272,8 @@ insert_addr_info(TID, Kind, Pid, AddrInfo) ->
 
 -spec lookup_addr_info(ets:tab(), atom(), pid()) -> {ok, {string(), string()}} | false.
 lookup_addr_info(TID, Kind, Pid) ->
-    case ets:lookup(TID, {{?ADDR_INFO, Kind, '$1'}, Pid}) of
-        [AddrInfo]  -> {ok, AddrInfo};
+    case ets:match(TID, {{?ADDR_INFO, Kind, '$1'}, Pid}) of
+        [[AddrInfo]]  -> {ok, AddrInfo};
         [] -> false
     end.
 

--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -5,6 +5,7 @@
          insert_pid/4, lookup_pid/3, lookup_pids/2, remove_pid/2, remove_pid/3,
          session/0, insert_session/3, lookup_session/2, lookup_session/3, remove_session/2,
          lookup_sessions/1, lookup_session_addrs/2, lookup_session_addrs/1,
+         insert_session_addr_info/3, lookup_session_addr_info/2,
          transport/0, insert_transport/3, lookup_transport/2, lookup_transports/1,
          listen_addrs/1, listener/0, lookup_listener/2, insert_listener/3, remove_listener/2,
          listen_socket/0, lookup_listen_socket/2, lookup_listen_socket_by_addr/2, insert_listen_socket/4, remove_listen_socket/2, listen_sockets/1,
@@ -29,6 +30,7 @@
 -define(RELAY_SESSIONS, relay_sessions).
 -define(PROXY, proxy).
 -define(NAT, nat).
+-define(ADDR_INFO, addr_info).
 
 -type handler() :: {atom(), atom()}.
 -type opts() :: [{atom(), any()}].
@@ -247,6 +249,35 @@ lookup_session_addrs(TID, Pid) ->
 -spec lookup_session_addrs(ets:tab()) -> [string()].
 lookup_session_addrs(TID) ->
     lookup_addrs(TID, ?SESSION).
+
+-spec lookup_session_addr_info(ets:tab(), pid()) -> {ok, {string(), string()}} | false.
+lookup_session_addr_info(TID, Pid) ->
+    lookup_addr_info(TID, ?SESSION, Pid).
+
+-spec insert_session_addr_info(ets:tab(), pid(), {string(), string()}) -> true.
+insert_session_addr_info(TID, Pid, AddrInfo) ->
+    insert_addr_info(TID, ?SESSION, Pid, AddrInfo).
+
+
+%%
+%% Addr Info
+%%
+
+-spec insert_addr_info(ets:tab(), atom(), pid(), {string(), string()}) -> true.
+insert_addr_info(TID, Kind, Pid, AddrInfo) ->
+    %% Insert in the form that remove_pid understands to ensure that
+    %% addr info gets removed for removed pids regardless of what kind
+    %% of addr_info it is
+    ets:insert(TID, {{?ADDR_INFO, Kind, AddrInfo}, Pid}).
+
+-spec lookup_addr_info(ets:tab(), atom(), pid()) -> {ok, {string(), string()}} | false.
+lookup_addr_info(TID, Kind, Pid) ->
+    case ets:lookup(TID, {{?ADDR_INFO, Kind, '$1'}, Pid}) of
+        [AddrInfo]  -> {ok, AddrInfo};
+        [] -> false
+    end.
+
+
 %%
 %% Connections
 %%

--- a/src/libp2p_session.erl
+++ b/src/libp2p_session.erl
@@ -6,7 +6,7 @@
 
 -export_type([stream_handler/0]).
 
--export([ping/1, open/1, close/1, close/3, close_state/1, goaway/1, streams/1, addr_info/1, identify/3]).
+-export([ping/1, open/1, close/1, close/3, close_state/1, goaway/1, streams/1, addr_info/2, identify/3]).
 
 -export([dial/2, dial_framed_stream/4]).
 
@@ -47,9 +47,12 @@ goaway(Pid) ->
 streams(Pid) ->
     gen_server:call(Pid, streams).
 
--spec addr_info(pid()) -> {string(), string()}.
-addr_info(Pid) ->
-    gen_server:call(Pid, addr_info).
+-spec addr_info(ets:tab(), pid()) -> {string(), string()}.
+addr_info(TID, Pid) ->
+    case libp2p_config:lookup_session_addr_info(TID, Pid) of
+        {ok, AddrInfo} -> AddrInfo;
+        false -> {"noproc", "noproc"}
+    end.
 
 -spec identify(pid(), Handler::pid(), HandlerData::any()) -> ok.
 identify(Pid, Handler, HandlerData) ->

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -45,7 +45,7 @@ handle_call(Msg, _From, State) ->
     {reply, ok, State}.
 
 handle_info({handle_identify, Session, {error, Error}}, State=#state{}) ->
-    {_, PeerAddr} = libp2p_session:addr_info(Session),
+    {_, PeerAddr} = libp2p_session:addr_info(State#state.tid, Session),
     lager:warning("ignoring session after failed identify ~p: ~p", [PeerAddr, Error]),
     {noreply, State};
 handle_info({handle_identify, Session, {ok, Identify}}, State=#state{tid=TID}) ->

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -220,8 +220,8 @@ start_server_session(Ref, TID, Connection) ->
     Handlers = [{Key, Handler} ||
                    {Key, {Handler, _}} <- libp2p_config:lookup_connection_handlers(TID)],
     {ok, SessionPid} = libp2p_multistream_server:start_link(Ref, Connection, Handlers, TID),
-    libp2p_config:insert_session(TID, RemoteAddr, SessionPid),
     AddrInfo = libp2p_connection:addr_info(Connection),
     libp2p_config:insert_session_addr_info(TID, SessionPid, AddrInfo),
+    libp2p_config:insert_session(TID, RemoteAddr, SessionPid),
     libp2p_swarm:register_session(libp2p_swarm:swarm(TID), SessionPid),
     {ok, SessionPid}.

--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -162,6 +162,8 @@ start_client_session(TID, Addr, Connection) ->
                     case libp2p_connection:controlling_process(Connection, SessionPid) of
                         {ok, _} ->
                             libp2p_config:insert_session(TID, Addr, SessionPid),
+                            AddrInfo = libp2p_connection:addr_info(Connection),
+                            libp2p_config:insert_session_addr_info(TID, SessionPid, AddrInfo),
                             libp2p_swarm:register_session(libp2p_swarm:swarm(TID), SessionPid),
                             {ok, SessionPid};
                         {error, Error} ->
@@ -185,6 +187,8 @@ start_client_session(TID, Addr, Connection) ->
             case libp2p_connection:controlling_process(Connection, SessionPid) of
                 {ok, _} ->
                     libp2p_config:insert_session(TID, Addr, SessionPid),
+                    AddrInfo = libp2p_connection:addr_info(Connection),
+                    libp2p_config:insert_session_addr_info(TID, SessionPid, AddrInfo),
                     libp2p_swarm:register_session(libp2p_swarm:swarm(TID), SessionPid),
                     {ok, SessionPid};
                 {error, Error} ->
@@ -217,5 +221,7 @@ start_server_session(Ref, TID, Connection) ->
                    {Key, {Handler, _}} <- libp2p_config:lookup_connection_handlers(TID)],
     {ok, SessionPid} = libp2p_multistream_server:start_link(Ref, Connection, Handlers, TID),
     libp2p_config:insert_session(TID, RemoteAddr, SessionPid),
+    AddrInfo = libp2p_connection:addr_info(Connection),
+    libp2p_config:insert_session_addr_info(TID, SessionPid, AddrInfo),
     libp2p_swarm:register_session(libp2p_swarm:swarm(TID), SessionPid),
     {ok, SessionPid}.

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -333,7 +333,7 @@ rfc1918(IP={172, _, _, _}) ->
 rfc1918(_) ->
     false.
 
--spec is_public(string()) -> boolean(). 
+-spec is_public(string()) -> boolean().
 is_public(Address) ->
     case ?MODULE:match_addr(Address) of
         false -> false;
@@ -409,7 +409,7 @@ handle_cast(Msg, State) ->
 %%  Discover/Stun
 %%
 handle_info({handle_identify, Session, {error, Error}}, State=#state{}) ->
-    {_LocalAddr, PeerAddr} = libp2p_session:addr_info(Session),
+    {_LocalAddr, PeerAddr} = libp2p_session:addr_info(State#state.tid, Session),
     lager:notice("session identification failed for ~p: ~p", [PeerAddr, Error]),
     {noreply, State};
 handle_info({handle_identify, Session, {ok, Identify}}, State) ->
@@ -852,7 +852,7 @@ mask_address(Addr={_, _, _, _}, Maskbits) ->
     Subnet.
 
 do_identify(Session, Identify, State=#state{tid=TID}) ->
-    {LocalAddr, _PeerAddr} = libp2p_session:addr_info(Session),
+    {LocalAddr, _PeerAddr} = libp2p_session:addr_info(State#state.tid, Session),
     RemoteP2PAddr = libp2p_crypto:pubkey_bin_to_p2p(libp2p_identify:pubkey_bin(Identify)),
     {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:pubkey_bin(TID)),
     ListenAddrs = libp2p_peer:listen_addrs(MyPeer),

--- a/test/session_SUITE.erl
+++ b/test/session_SUITE.erl
@@ -57,7 +57,7 @@ open_close_test(Config) ->
 
     {ok, Conn1} = libp2p_session:open(Session1),
     Conn1Pid = ConnPid(Conn1),
-    true = libp2p_connection:addr_info(Conn1) == libp2p_session:addr_info(Session1),
+    true = libp2p_connection:addr_info(Conn1) == libp2p_session:addr_info(libp2p_swarm:tid(S1), Session1),
     ok = test_util:wait_until(fun() ->
                                       lists:any(fun(P) -> ConnPid(P) == Conn1Pid end,
                                                 libp2p_session:streams(Session1))

--- a/test/session_SUITE.erl
+++ b/test/session_SUITE.erl
@@ -76,6 +76,7 @@ open_close_test(Config) ->
     {error, closed} = libp2p_connection:send(Conn1, <<"hello">>),
 
     ok = libp2p_session:close(Session1),
+    {"noproc", "noproc"} = libp2p_session:addr_info(libp2p_swarm:tid(S1), Session1),
 
     ok.
 


### PR DESCRIPTION
Caches session addr_info information in the swarm's ets table to allow lookup even if the session is not alive