### PR TITLE
Allow for secured streams to share enacl keypairs

### DIFF
--- a/test/libp2p_secure_framed_stream_SUITE.erl
+++ b/test/libp2p_secure_framed_stream_SUITE.erl
@@ -204,12 +204,13 @@ stream(_Config) ->
 
     gen_server:stop(ClientStream0),
 
+    Keys = libp2p_framed_stream:mk_secured_keypair(ClientSwarm),
     {ok, ClientStream} = libp2p_swarm:dial_framed_stream(
         ClientSwarm,
         libp2p_swarm:p2p_address(ServerSwarm),
         Version,
         libp2p_secure_framed_stream_echo_test,
-        [self(), {secured, ClientSwarm}]
+        [self(), {secured, ClientSwarm}, {keys, Keys}]
     ),
 
     lists:foreach(


### PR DESCRIPTION
Allow keys to be passed in to a secured framed stream. Use this in relcast to share a keypair across all group workers. This should lighten the load on the signing subsystem. 

Since each group member in relcast has it's own keypair, each session key for any two connected members of a group is still unique 