### PR TITLE
don't crash on dead relcast getting input

### DIFF
--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -209,6 +209,9 @@ handle_cast({request_target, Index, WorkerPid}, State=#state{tid=TID}) ->
     {noreply, NewState};
 handle_cast({handle_input, _Msg}, State=#state{close_state=closing}) ->
     {noreply, State};
+handle_cast({handle_input, _Msg}, State=#state{store=Bad}) when Bad == not_started orelse
+                                                                Bad == cannot_start ->
+    {noreply, State};
 handle_cast({handle_input, Msg}, State=#state{store=Relcast}) ->
     case relcast:command(Msg, Relcast) of
         {_Reply, NewRelcast} ->


### PR DESCRIPTION
cleanup an ugly crash that causes problems for dkg restores.