### PR TITLE
Avoid crashing the relay server when possible & clean up dead relays

### DIFF
--- a/src/relay/libp2p_relay_server.erl
+++ b/src/relay/libp2p_relay_server.erl
@@ -92,6 +92,15 @@ negotiated(Swarm, Address) ->
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 init(TID) ->
+    %% remove any prior relay addresses we somehow leaked
+    lists:foreach(fun(Addr) ->
+                          case libp2p_transport_relay:match_addr(Addr,TID) of
+                              {ok, _} ->
+                                  libp2p_config:remove_listener(TID, Addr);
+                              _ ->
+                                  ok
+                          end
+                  end, libp2p_config:listen_addrs(TID)),
     lager:info("~p init with ~p", [?MODULE, TID]),
     true = libp2p_config:insert_relay(TID, self()),
     {ok, #state{tid=TID}}.

--- a/src/relay/libp2p_relay_server.erl
+++ b/src/relay/libp2p_relay_server.erl
@@ -197,9 +197,11 @@ handle_info(_Msg, State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-terminate(_Reason, #state{tid=TID, stream=Pid}) when is_pid(Pid) ->
+terminate(_Reason, #state{tid=TID, stream=Pid, address=Address}) when is_pid(Pid) ->
     catch libp2p_framed_stream:close(Pid),
     true = libp2p_config:remove_relay(TID),
+    %% remove listener is harmless if the address is undefined
+    _ = libp2p_config:remove_listener(TID, Address),
     ok;
 terminate(_Reason, _State) ->
     ok.

--- a/src/relay/libp2p_stream_relay.erl
+++ b/src/relay/libp2p_stream_relay.erl
@@ -97,7 +97,7 @@ handle_info(client, init_relay, #state{swarm=Swarm}=State) ->
     case libp2p_swarm:listen_addrs(Swarm) of
         [] ->
             lager:debug("no listen addresses for ~p, relay disabled", [Swarm]),
-            {stop, no_listen_address, State};
+            {stop, normal, State};
         [_|_] ->
             Address = libp2p_swarm:p2p_address(Swarm),
             Req = libp2p_relay_req:create(Address),
@@ -133,10 +133,10 @@ handle_info(client, send_ping, State = #state{ping_seq=Seq, swarm=Swarm, relay_a
     case libp2p_relay:is_valid_peer(Swarm, RelayServerPubKeyBin) of
         {error, _Reason} ->
             lager:error("failed to get peer for~p: ~p", [RelayServer, _Reason]),
-            {stop, no_peer, State};
+            {stop, normal, State};
         false ->
             lager:warning("peer ~p is invalid going down", [RelayServer]),
-            {stop, invalid_peer, State};
+            {stop, normal, State};
         true ->
             Ping = libp2p_relay_ping:create_ping(Seq),
             Env = libp2p_relay_envelope:create(Ping),


### PR DESCRIPTION
The relay streams are linked to the relay server, so don't exit
non-normal without a good reason. Additionally, if the relay server hits
the terminate function, remove the active relay address on the way down.