### PR TITLE
Gossip a random subset of the updated peers to gossip peers

### DIFF
--- a/src/group/libp2p_group_gossip.erl
+++ b/src/group/libp2p_group_gossip.erl
@@ -25,8 +25,8 @@ remove_handler(Pid, Key) ->
 %% @doc Send the given data to all members of the group for the given
 %% gossip key. The implementation of the group determines the strategy
 %% used for delivery. Delivery is best effort.
--spec send(pid(), string(), iodata()) -> ok.
-send(Pid, Key, Data) when is_list(Key), is_binary(Data) ->
+-spec send(pid(), string(), iodata() | fun(() -> iodata())) -> ok.
+send(Pid, Key, Data) when is_list(Key), is_binary(Data) orelse is_function(Data) ->
     gen_server:cast(Pid, {send, Key, Data}).
 
 -spec connected_addrs(pid(), connection_kind() | all) -> [string()].


### PR DESCRIPTION
Previously we'd accumulate a large list of peers that had updated within
an interval and then gossip that entire list to all our gossip peers.

Instead this change sends a distinct random subset of the updated peers
to all connected gossip peers in an attempt to limit bandwidth.