### PR TITLE
yamux stream monitoring

### DIFF
--- a/src/libp2p_connection.erl
+++ b/src/libp2p_connection.erl
@@ -14,7 +14,7 @@
          recv/1, recv/2, recv/3,
          acknowledge/2, fdset/1, socket/1, fdclr/1,
          addr_info/1, close/1, close_state/1,
-         controlling_process/2, session/1,
+         controlling_process/2, session/1, monitor/1,
          set_idle_timeout/2]).
 -export([mk_async_sender/2]).
 
@@ -29,6 +29,7 @@
 -callback session(any()) -> {ok, pid()} | {error, term()}.
 -callback set_idle_timeout(any(), pos_integer() | infinity) -> ok | {error, term()}.
 -callback controlling_process(any(), pid()) ->  {ok, any()} | {error, closed | not_owner | atom()}.
+-callback monitor(any()) -> reference().
 
 -define(RECV_TIMEOUT, 60000).
 -define(SEND_TIMEOUT, 60000).
@@ -103,6 +104,9 @@ controlling_process(Conn=#connection{module=Module, state=State}, Pid) ->
         Other -> Other
     end.
 
+-spec monitor(connection())-> reference().
+monitor(#connection{module=Module, state=State}) ->
+    Module:monitor(State).
 
 %%
 %% Utilities

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -43,7 +43,7 @@
 %% libp2p_connection
 -export([send/3, recv/3, acknowledge/2, addr_info/1,
          close/1, close_state/1, controlling_process/2,
-         session/1, fdset/1, socket/1, fdclr/1,
+         session/1, fdset/1, socket/1, fdclr/1, monitor/1,
          set_idle_timeout/2
         ]).
 
@@ -307,6 +307,11 @@ controlling_process(State=#tcp_state{socket=Socket}, Pid) ->
         ok -> {ok, State#tcp_state{session=Pid}};
         Other -> Other
     end.
+
+%% this is faked out because it's already handled in framed stream,
+%% which is the only user of monitor
+monitor(_) ->
+    make_ref().
 
 -spec common_options() -> [term()].
 common_options() ->


### PR DESCRIPTION
for some reason the rate of session errors has climbed, and we're having some issues recovering.  this PR threads monitoring up from the yamux session/stream/connection so that when the underlying connection goes away, everything above it dies so monitoring is triggered.