### PR TITLE
supress uninformative errors when too many peers try to connect

### DIFF
--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -45,6 +45,8 @@ init(server, Connection, [HandlerModule, HandlerState]) ->
         ok -> {ok, #state{connection=Connection,
                           handler_module=HandlerModule,
                           handler_state=HandlerState}};
+        {error, too_many} ->
+            {stop, normal};
         {error, Reason} ->
             lager:warning("Stopping on accept stream error: ~p", [Reason]),
             {stop, {error, Reason}};

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -229,8 +229,8 @@ handle_info({handle_identify, {From, StreamPid}, {ok, Identify}}, State=#state{}
         false ->
             case count_workers(inbound, State) > State#state.max_inbound_connections of
                 true ->
-                    lager:notice("Too many inbound workers: ~p",
-                                 [State#state.max_inbound_connections]),
+                    lager:debug("Too many inbound workers: ~p",
+                                [State#state.max_inbound_connections]),
                     gen_server:reply(From, {error, too_many}),
                     {noreply, State};
                 false ->


### PR DESCRIPTION
we don't need to know at notice level that we're rejecting peers because too we have too many gossip connections already.