### PR TITLE
Don't put RFC1918 addresses in peerbook entries by default

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -335,6 +335,15 @@ rfc1918(IP={172, _, _, _}) ->
         false ->
             false
     end;
+rfc1918(MA) when is_list(MA) ->
+    case tcp_addr(MA) of
+        {IP, _Port, inet, _} ->
+            case rfc1918(IP) of
+                false -> false;
+                true -> true
+            end;
+        _ -> false
+    end;
 rfc1918(_) ->
     false.
 
@@ -881,8 +890,7 @@ mask_address(Addr={_, _, _, _}, Maskbits) ->
 do_identify(Session, Identify, State=#state{tid=TID}) ->
     {LocalAddr, _PeerAddr} = libp2p_session:addr_info(State#state.tid, Session),
     RemoteP2PAddr = libp2p_crypto:pubkey_bin_to_p2p(libp2p_identify:pubkey_bin(Identify)),
-    {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:pubkey_bin(TID)),
-    ListenAddrs = libp2p_peer:listen_addrs(MyPeer),
+    ListenAddrs = libp2p_config:listen_addrs(TID),
     case lists:member(LocalAddr, ListenAddrs) of
         true ->
             ObservedAddr = libp2p_identify:observed_addr(Identify),

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -20,7 +20,7 @@
 -export([from_map/2, encode/1, decode/1, decode_unsafe/1, encode_list/1, decode_list/1, verify/1,
          pubkey_bin/1, listen_addrs/1, connected_peers/1, nat_type/1, timestamp/1,
          supersedes/2, is_stale/2, is_similar/2, network_id/1, network_id_allowable/2,
-         has_public_ip/1, is_dialable/1]).
+         has_private_ip/1, has_public_ip/1, is_dialable/1]).
 %% associations
 -export([associations/1, association_pubkey_bins/1, associations_set/4, associations_get/2, associations_put/4,
          is_association/3, association_pubkey_bin/1, association_signature/1,
@@ -296,6 +296,13 @@ network_id_allowable(Peer, MyNetworkID) ->
 has_public_ip(Peer) ->
     ListenAddresses = ?MODULE:listen_addrs(Peer),
     lists:any(fun libp2p_transport_tcp:is_public/1, ListenAddresses).
+
+%% @doc Returns whether the peer is publishing a RFC1918 address
+-spec has_private_ip(peer()) -> boolean().
+has_private_ip(Peer) ->
+    ListenAddresses = ?MODULE:listen_addrs(Peer),
+    not lists:all(fun libp2p_transport_tcp:is_public/1, ListenAddresses).
+
 
 %% @doc Returns whether the peer is dialable. A peer is dialable if it
 %% has a public IP address or it is reachable via a relay address.


### PR DESCRIPTION
Additionally, don't gossip peer entries if they do not have a listen
address or any peer connections.

Finally add some commented out code to reject peers that send us
peerbook updates containing RFC1918 addresses if we're configured not to
use them. This should be activated later once the network has fully
upgraded to not publishing them.