### PR TITLE
Add gossip stream pid to delivered gossip message 

### DIFF
--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -4,7 +4,7 @@
 
 -behavior(libp2p_framed_stream).
 
--callback handle_data(State::any(), Key::string(), Msg::binary()) -> ok.
+-callback handle_data(State::any(), StreamPid::pid(), Key::string(), Msg::binary()) -> ok.
 -callback accept_stream(State::any(),
                         Session::pid(),
                         Stream::pid()) -> ok | {error, term()}.
@@ -65,5 +65,5 @@ handle_data(_, Data, State=#state{handler_module=HandlerModule,
     #libp2p_gossip_frame_pb{key=Key, data=Bin} =
         libp2p_gossip_pb:decode_msg(Data, libp2p_gossip_frame_pb),
 
-    ok = HandlerModule:handle_data(HandlerState, Key, Bin),
+    ok = HandlerModule:handle_data(HandlerState, self(), Key, Bin),
     {noreply, State}.

--- a/src/group/libp2p_group_gossip_handler.erl
+++ b/src/group/libp2p_group_gossip_handler.erl
@@ -2,7 +2,7 @@
 
 
 -callback init_gossip_data(State::any()) -> init_result().
--callback handle_gossip_data(Msg::binary(), State::any()) -> ok.
+-callback handle_gossip_data(StreamPid::pid(), Msg::binary(), State::any()) -> ok.
 
 -type init_result() :: ok | {send, binary()}.
 

--- a/src/libp2p_framed_stream.erl
+++ b/src/libp2p_framed_stream.erl
@@ -214,7 +214,9 @@ init_module(Kind, Module, Connection, Args, SendPid) ->
             {error, Reason};
         {stop, Reason, Response} ->
             {ok, handle_fdset(handle_resp_send({stop, Reason}, Response,
-                                               #state{kind=Kind, connection=Connection, send_pid=SendPid,
+                                               #state{kind=Kind,
+                                                      connection=Connection, conn_ref=Ref,
+                                                      send_pid=SendPid,
                                                       module=Module, state=undefined}))}
     end.
 

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -6,7 +6,7 @@
          register_session/3, unregister_session/2, blacklist_listen_addr/3,
          add_association/3, lookup_association/3]).
 %% libp2p_group_gossip_handler
--export([handle_gossip_data/2, init_gossip_data/1]).
+-export([handle_gossip_data/3, init_gossip_data/1]).
 
 -type opt() :: {stale_time, pos_integer()}
              | {peer_time, pos_integer()}.
@@ -194,8 +194,8 @@ lookup_association(Handle=#peerbook{}, AssocType, AssocAddress) ->
 %% Gossip Group
 %%
 
--spec handle_gossip_data(binary(), peerbook()) -> ok.
-handle_gossip_data(Data, Handle) ->
+-spec handle_gossip_data(StreamPid::pid(), binary(), peerbook()) -> ok.
+handle_gossip_data(_, Data, Handle) ->
     DecodedList = libp2p_peer:decode_list(Data),
     ?MODULE:put(Handle, DecodedList).
 
@@ -585,4 +585,3 @@ get_async_signed_metadata(State = #state{metadata_ref=undefined, metadata_fun=Me
 get_async_signed_metadata(State) ->
     %% metadata fun still running
     State.
-

--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -7,7 +7,7 @@
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 -export([connection_test/1, gossip_test/1, seed_test/1]).
--export([init_gossip_data/1, handle_gossip_data/2]).
+-export([init_gossip_data/1, handle_gossip_data/3]).
 
 all() ->
     [
@@ -129,7 +129,7 @@ seed_test(Config) ->
 init_gossip_data(_) ->
      ok.
 
-handle_gossip_data(Msg, Parent) ->
+handle_gossip_data(_StreamPid, Msg, Parent) ->
     Parent ! {handle_gossip_data, Msg},
     ok.
 


### PR DESCRIPTION
This adds the gossip stream to the delivered gossip message to allow us to send something back to the sender out of band. 

This is a hack which will not be supported in the new stream/gossip setup, please don't rely on it too much. 