### PR TITLE
Remove the gossip server's peer cache

### DIFF
--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -1,7 +1,7 @@
 -module(libp2p_peerbook).
 
 -export([start_link/2, init/1, handle_call/3, handle_info/2, handle_cast/2, terminate/2]).
--export([keys/1, values/1, put/2,get/2, refresh/2, is_key/2, remove/2, stale_time/1,
+-export([keys/1, values/1, put/2,get/2, random/1, random/2, refresh/2, is_key/2, remove/2, stale_time/1,
          join_notify/2, changed_listener/1, update_nat_type/2,
          register_session/3, unregister_session/2, blacklist_listen_addr/3,
          add_association/3, lookup_association/3]).
@@ -115,6 +115,54 @@ get(#peerbook{tid=TID}=Handle, ID) ->
                     {error, not_found};
                 true ->
                     {ok, Peer}
+            end
+    end.
+
+random(Peerbook) ->
+    random(Peerbook, [], 5).
+
+random(Peerbook, Exclude) ->
+    random(Peerbook, Exclude, 5).
+
+random(_, _, 0) ->
+    false;
+random(Peerbook=#peerbook{store=Store}, Exclude, Tries) ->
+    {ok, Iterator} = rocksdb:iterator(Store, []),
+    {ok, FirstAddr = <<Start:(33*8)/integer-unsigned-big>>, FirstPeer} = rocksdb:iterator_move(Iterator, first),
+    {ok, <<End:(33*8)/integer-unsigned-big>>, _} = rocksdb:iterator_move(Iterator, last),
+    Difference = End - Start,
+    case Difference of
+        0 ->
+            rocksdb:iterator_close(Iterator),
+            %% only have one peer
+            case lists:member(FirstAddr, Exclude) of
+                true ->
+                    %% only peer we have is excluded
+                    false;
+                false ->
+                    try libp2p_peer:decode(FirstPeer) of
+                        Peer -> {FirstAddr, Peer}
+                    catch
+                        _:_ ->
+                            %% only peer we have is junk
+                            false
+                    end
+            end;
+        _ ->
+            Offset = rand:uniform(Difference),
+            SeekPoint = Start + Offset,
+            {ok, Addr, Bin} = rocksdb:iterator_move(Iterator, <<SeekPoint:(33*8)/integer-unsigned-big>>),
+            rocksdb:iterator_close(Iterator),
+            case lists:member(Addr, Exclude) of
+                true ->
+                    random(Peerbook, Exclude, Tries - 1);
+                false ->
+                    try libp2p_peer:decode(Bin) of
+                        Peer -> {Addr, Peer}
+                    catch
+                        _:_ ->
+                            random(Peerbook, [Addr, Exclude], Tries - 1)
+                    end
             end
     end.
 


### PR DESCRIPTION
The intent of the peer cache was to quickly provide a random peer for a
gossip worker by storing all the peerbook addresses as p2p addresses in
the gossip server's state. This doesn't scale at all AND storing the p2p
address instead of the pubkey bin means that we pay the 4x memory
overhead of storing strings (32 bit code points) and can't benefit from
binary sharing.

This patch adds peerbook:random/1 and random/2 for quickly (2000
microseconds) getting a random peer from the peerbook. With random/2,
a list of peer addresses to exclude from selection is provided.