### PR TITLE
use registered names in all permanent sups and processes

### DIFF
--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -41,7 +41,10 @@
 %%
 
 start_link(Sup, TID) ->
-    gen_server:start_link(?MODULE, [Sup, TID], [{hibernate_after, 5000}]).
+    gen_server:start_link(reg_name(TID), ?MODULE, [Sup, TID], [{hibernate_after, 5000}]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 %% libp2p_gossip_stream
 %%

--- a/src/group/libp2p_group_gossip_sup.erl
+++ b/src/group/libp2p_group_gossip_sup.erl
@@ -20,7 +20,7 @@ init([TID]) ->
     ChildSpecs =
         [
          #{ id => ?WORKERS,
-            start => {libp2p_group_worker_sup, start_link, [TID]},
+            start => {libp2p_group_worker_sup, start_link, []},
             type => supervisor
           },
          #{ id => server,

--- a/src/group/libp2p_group_gossip_sup.erl
+++ b/src/group/libp2p_group_gossip_sup.erl
@@ -10,14 +10,17 @@
 -define(WORKERS, workers).
 
 start_link(TID) ->
-    supervisor:start_link(?MODULE, [TID]).
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID]) ->
     SupFlags = #{strategy => one_for_all},
     ChildSpecs =
         [
          #{ id => ?WORKERS,
-            start => {libp2p_group_worker_sup, start_link, []},
+            start => {libp2p_group_worker_sup, start_link, [TID]},
             type => supervisor
           },
          #{ id => server,

--- a/src/group/libp2p_group_mgr.erl
+++ b/src/group/libp2p_group_mgr.erl
@@ -29,7 +29,10 @@
 %%%===================================================================
 
 start_link(TID, Predicate) ->
-    gen_server:start_link(?MODULE, [TID, Predicate], []).
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID, Predicate], []).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 mgr(TID) ->
     ets:lookup_element(TID, ?SERVER, 2).

--- a/src/group/libp2p_group_worker_sup.erl
+++ b/src/group/libp2p_group_worker_sup.erl
@@ -2,15 +2,12 @@
 
 -behavior(supervisor).
 
--export([start_link/1, init/1]).
+-export([start_link/0, init/1]).
 
-start_link(TID) ->
-    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+start_link() ->
+    supervisor:start_link(?MODULE, []).
 
-reg_name(TID)->
-    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
-
-init([_TID]) ->
+init([]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 100
                 },

--- a/src/group/libp2p_group_worker_sup.erl
+++ b/src/group/libp2p_group_worker_sup.erl
@@ -2,13 +2,15 @@
 
 -behavior(supervisor).
 
--export([start_link/0, init/1]).
+-export([start_link/1, init/1]).
 
-start_link() ->
-    supervisor:start_link(?MODULE, []).
+start_link(TID) ->
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
 
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
-init([]) ->
+init([_TID]) ->
     SupFlags = #{strategy => one_for_one,
                  intensity => 100
                 },

--- a/src/libp2p_cache.erl
+++ b/src/libp2p_cache.erl
@@ -40,9 +40,11 @@
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link(?MODULE, [Args], []).
+start_link(TID) ->
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID], []).
 
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 %%--------------------------------------------------------------------
 %% @doc
 %% @end
@@ -126,11 +128,11 @@ migrate(Dets) ->
             dets:delete(Dets, Key);
         (Key0, Key1, _) ->
             case dets:lookup(Dets, Key0) of
-                [] -> 
+                [] ->
                     ok;
-                [{Key0, Value}] -> 
+                [{Key0, Value}] ->
                     dets:insert(Dets, {Key1, Value});
-                [{Key0, Value}|_]-> 
+                [{Key0, Value}|_]->
                     dets:insert(Dets, {Key1, Value})
             end,
             dets:delete(Dets, Key0)

--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -32,6 +32,7 @@
 -define(NAT, nat).
 -define(ADDR_INFO, addr_info).
 
+
 -type handler() :: {atom(), atom()}.
 -type opts() :: [{atom(), any()}].
 
@@ -75,6 +76,7 @@ swarm_dir(TID, Names) ->
     FileName = filename:join([base_dir(TID), libp2p_swarm:name(TID) | Names]),
     ok = filelib:ensure_dir(FileName),
     FileName.
+
 
 %%
 %% Common pid CRUD

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -12,7 +12,8 @@
          add_stream_handler/3, remove_stream_handler/2, stream_handlers/1,
          register_session/2, register_listener/2,
          add_group/4, remove_group/2,
-         gossip_group/1]).
+         gossip_group/1,
+         reg_name_from_tid/2]).
 
 -type swarm_opts() :: [swarm_opt()].
 -type connect_opts() :: [connect_opt()].
@@ -46,12 +47,17 @@ start(Name) when is_atom(Name) ->
 %% control behavior of various subsystems of the swarm.
 -spec start(atom(), swarm_opts()) -> {ok, pid()} | ignore | {error, term()}.
 start(Name, Opts)  ->
-    case supervisor:start_link(libp2p_swarm_sup, [Name, Opts]) of
+    case supervisor:start_link({local, Name}, libp2p_swarm_sup, [Name, Opts]) of
         {ok, Pid} ->
             unlink(Pid),
             {ok, Pid};
         Other -> Other
     end.
+
+%% @doc returns an atom to be used as the registered name of a process
+-spec reg_name_from_tid(ets:tab(), atom()) -> atom().
+reg_name_from_tid(TID, Module)->
+    list_to_atom(atom_to_list(Module) ++ "_" ++ atom_to_list(name(TID))).
 
 %% @doc Stops the given swarm.
 -spec stop(pid()) -> ok.

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -47,7 +47,8 @@ start(Name) when is_atom(Name) ->
 %% control behavior of various subsystems of the swarm.
 -spec start(atom(), swarm_opts()) -> {ok, pid()} | ignore | {error, term()}.
 start(Name, Opts)  ->
-    case supervisor:start_link({local, Name}, libp2p_swarm_sup, [Name, Opts]) of
+    RegName = list_to_atom(atom_to_list(libp2p_swarm_sup) ++ "_" ++ atom_to_list(Name)),
+    case supervisor:start_link({local,RegName}, libp2p_swarm_sup, [Name, Opts]) of
         {ok, Pid} ->
             unlink(Pid),
             {ok, Pid};
@@ -58,6 +59,7 @@ start(Name, Opts)  ->
 -spec reg_name_from_tid(ets:tab(), atom()) -> atom().
 reg_name_from_tid(TID, Module)->
     list_to_atom(atom_to_list(Module) ++ "_" ++ atom_to_list(name(TID))).
+
 
 %% @doc Stops the given swarm.
 -spec stop(pid()) -> ok.

--- a/src/libp2p_swarm_auxiliary_sup.erl
+++ b/src/libp2p_swarm_auxiliary_sup.erl
@@ -25,8 +25,11 @@
 %%====================================================================
 %% API functions
 %%====================================================================
-start_link(Args) ->
-    supervisor:start_link(?MODULE, Args).
+start_link([TID, _Opts] = Args) ->
+    supervisor:start_link(reg_name(TID), ?MODULE, Args).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 register_cache(TID) ->
     ets:insert(TID, {?CACHE, self()}).
@@ -46,9 +49,9 @@ init([TID, Opts]) ->
     },
     Specs = [
         ?WORKER(?CACHE, libp2p_cache, [TID]),
-        ?WORKER(nat, libp2p_nat_server, [[TID]]),
+        ?WORKER(nat, libp2p_nat_server, [TID]),
         ?WORKER(relay, libp2p_relay_server, [TID]),
-        ?WORKER(proxy, libp2p_proxy_server, [[TID, libp2p_proxy:limit(Opts)]])
+        ?WORKER(proxy, libp2p_proxy_server, [TID, libp2p_proxy:limit(Opts)])
     ],
     {ok, {SupFlags, Specs}}.
 

--- a/src/libp2p_swarm_group_sup.erl
+++ b/src/libp2p_swarm_group_sup.erl
@@ -10,7 +10,10 @@
 -define(SUP, group_sup).
 
 start_link(TID) ->
-    supervisor:start_link(?MODULE, [TID]).
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID]) ->
     _ = ets:insert(TID, {?SUP, self()}),

--- a/src/libp2p_swarm_listener_sup.erl
+++ b/src/libp2p_swarm_listener_sup.erl
@@ -10,7 +10,10 @@
 -define(SUP, listener_sup).
 
 start_link(TID) ->
-    supervisor:start_link(?MODULE, [TID]).
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID]) ->
     _ = ets:insert(TID, {?SUP, self()}),
@@ -20,3 +23,5 @@ init([TID]) ->
 -spec sup(ets:tab()) -> pid().
 sup(TID) ->
     ets:lookup_element(TID, ?SUP, 2).
+
+

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -15,7 +15,10 @@
 %%
 
 start_link(TID, SigFun, ECDHFun) ->
-    gen_server:start_link(?MODULE, [TID, SigFun, ECDHFun], []).
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID, SigFun, ECDHFun], []).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID, SigFun, ECDHFun]) ->
     erlang:process_flag(trap_exit, true),

--- a/src/libp2p_swarm_session_sup.erl
+++ b/src/libp2p_swarm_session_sup.erl
@@ -10,7 +10,10 @@
 -define(SUP, connection_sup).
 
 start_link(TID) ->
-    supervisor:start_link(?MODULE, [TID]).
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID]) ->
     _ = ets:insert(TID, {?SUP, self()}),

--- a/src/libp2p_swarm_transport_sup.erl
+++ b/src/libp2p_swarm_transport_sup.erl
@@ -10,7 +10,10 @@
 -define(SUP, transport_sup).
 
 start_link(TID) ->
-    supervisor:start_link(?MODULE, [TID]).
+    supervisor:start_link(reg_name(TID), ?MODULE, [TID]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID]) ->
     _ = ets:insert(TID, {?SUP, self()}),

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -43,8 +43,11 @@
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, []).
+start_link(TID) ->
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID], []).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -57,7 +60,7 @@ register(TID, TransportPid, MultiAddr, IntPort) ->
         {ok, Pid} ->
             gen_server:call(Pid, {register, TransportPid, MultiAddr, IntPort})
     end.
-    
+
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -317,7 +317,10 @@ init_gossip_data(Handle=#peerbook{tid=TID}) ->
 %%
 
 start_link(TID, SigFun) ->
-    gen_server:start_link(?MODULE, [TID, SigFun], [{hibernate_after, 5000}]).
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID, SigFun], [{hibernate_after, 5000}]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 init([TID, SigFun]) ->
     erlang:process_flag(trap_exit, true),

--- a/src/proxy/libp2p_proxy_server.erl
+++ b/src/proxy/libp2p_proxy_server.erl
@@ -11,7 +11,7 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 -export([
-    start_link/1,
+    start_link/2,
     proxy/4,
     connection/3
 ]).
@@ -50,9 +50,11 @@
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, []).
+start_link(TID, Limit) ->
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID, Limit], []).
 
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 %%--------------------------------------------------------------------
 %% @doc
 %% @end

--- a/src/relay/libp2p_relay_server.erl
+++ b/src/relay/libp2p_relay_server.erl
@@ -50,8 +50,11 @@
 %% ------------------------------------------------------------------
 %% API Function Definitions
 %% ------------------------------------------------------------------
-start_link(Args) ->
-    gen_server:start_link(?MODULE, Args, [{hibernate_after, 5000}]).
+start_link(TID) ->
+    gen_server:start_link(reg_name(TID), ?MODULE, [TID], [{hibernate_after, 5000}]).
+
+reg_name(TID)->
+    {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
 -spec relay(pid()) -> ok | {error, any()}.
 relay(Swarm) ->
@@ -92,7 +95,7 @@ negotiated(Swarm, Address) ->
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
-init(TID) ->
+init([TID]) ->
     %% remove any prior relay addresses we somehow leaked
     lists:foreach(fun(Addr) ->
                           case libp2p_transport_relay:match_addr(Addr,TID) of

--- a/test/listen_SUITE.erl
+++ b/test/listen_SUITE.erl
@@ -132,7 +132,6 @@ port0_reuse(_Config) ->
     SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
 
     {ok, Swarm} = libp2p_swarm:start(listen_port0_reuse, SwarmOpts),
-    true = erlang:register(test, Swarm),
     ok = libp2p_swarm:listen(Swarm, "/ip4/0.0.0.0/tcp/0"),
     ok = libp2p_swarm:listen(Swarm, "/ip6/::/tcp/0"),
 


### PR DESCRIPTION
Add registered names to permanent or static sups and processes.
Reg name convention is $ModuleName_SwarmName

