### PR TITLE
change closing gossip stream from async to sync

### DIFF
--- a/src/group/libp2p_group_gossip.erl
+++ b/src/group/libp2p_group_gossip.erl
@@ -20,7 +20,7 @@ add_handler(Pid, Key, Handler) ->
 
 -spec remove_handler(pid(), string()) -> ok.
 remove_handler(Pid, Key) ->
-    gen_server:cast(Pid, {remove_handler, Key}).
+    gen_server:call(Pid, {remove_handler, Key}, 3000).
 
 %% @doc Send the given data to all members of the group for the given
 %% gossip key. The implementation of the group determines the strategy

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -82,6 +82,8 @@ handle_call({accept_stream, Session, StreamPid}, From, State=#state{}) ->
 handle_call({connected_addrs, Kind}, _From, State=#state{}) ->
     {Addrs, _Pids} = lists:unzip(connections(Kind, State)),
     {reply, Addrs, State};
+handle_call({remove_handler, Key}, _From, State=#state{handlers=Handlers}) ->
+    {reply, ok, State#state{handlers=maps:remove(Key, Handlers)}};
 
 handle_call(Msg, _From, State) ->
     lager:warning("Unhandled call: ~p", [Msg]),
@@ -114,9 +116,6 @@ handle_cast({handle_data, StreamPid, Key, Msg}, State=#state{}) ->
 
 handle_cast({add_handler, Key, Handler}, State=#state{handlers=Handlers}) ->
     {noreply, State#state{handlers=maps:put(Key, Handler, Handlers)}};
-handle_cast({remove_handler, Key}, State=#state{handlers=Handlers}) ->
-    {noreply, State#state{handlers=maps:remove(Key, Handlers)}};
-
 handle_cast({request_target, inbound, WorkerPid}, State=#state{}) ->
     {noreply, stop_inbound_worker(WorkerPid, State)};
 handle_cast({request_target, peerbook, WorkerPid}, State=#state{tid=TID}) ->


### PR DESCRIPTION
This is part of the wider task to achieve a cleaner miner shutdown.

Switching this from async to sync ensures that during the termination of the blockchain gossip handler as part of the blockchain worker terminate process we prevent any leaking msgs being gossipped and attempts made to route to the closed or closing blockchain worker