### PR TITLE
up relay lifetime to reflect realistic gossip staleness

### DIFF
--- a/src/relay/libp2p_relay_server.erl
+++ b/src/relay/libp2p_relay_server.erl
@@ -44,7 +44,7 @@
 
 -define(FLAP_LIMIT, 3).
 -define(BANLIST_TIMEOUT, timer:minutes(5)).
--define(MAX_RELAY_DURATION, timer:minutes(30)).
+-define(MAX_RELAY_DURATION, timer:minutes(90)).
 -define(MAX_PEERS, 500).
 
 %% ------------------------------------------------------------------


### PR DESCRIPTION
it seems like 60% of our peer gossip values are older than 15 minutes.  forcing things to churn so quickly means that most of the values will have been forced to churn well before they're replaced.  letting healthy connections go longer means they're more likely to be accurate when they're needed.