### PR TITLE
store similar peers, add debugging to relcast exits.

### DIFF
--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -350,6 +350,7 @@ handle_info(force_close, State=#state{}) ->
     %% The timeout after the handler returned close has fired. Shut
     %% down the group by exiting the supervisor.
     spawn(fun() ->
+                  lager:info("removing group for force_close timeout"),
                   libp2p_swarm:remove_group(State#state.tid, State#state.group_id)
           end),
     {noreply, State#state{close_state=closing}};


### PR DESCRIPTION
Currently, although we've gotten a new peer, we gate both storage and gossip on the same filter.  This PR stores peers as long as they're an updated, but does not gossip them, in the grounds that we've already paid the price of deserializing and testing the peer, so we might as well take the updated information.