### PR TITLE
adjust libp2p gossip strategies

### DIFF
--- a/src/peerbook/libp2p_peer_resolution.erl
+++ b/src/peerbook/libp2p_peer_resolution.erl
@@ -22,7 +22,7 @@ resolve(GossipGroup, PK, Ts) ->
     ok.
 
 install_handler(G, Handle) ->
-    throttle:setup(?MODULE, 3, per_minute),
+    throttle:setup(?MODULE, 10, per_minute),
     libp2p_group_gossip:add_handler(G,  ?GOSSIP_GROUP_KEY, {?MODULE, Handle}),
     ok.
 

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -200,7 +200,7 @@ refresh(#peerbook{tid=TID}=Handle, ID) when is_binary(ID) ->
             end
     end;
 refresh(#peerbook{tid=TID}, Peer) ->
-    TimeDiffMinutes = application:get_env(libp2p, similarity_time_diff_mins, 6),
+    TimeDiffMinutes = application:get_env(libp2p, similarity_time_diff_mins, 1),
     case libp2p_peer:network_id_allowable(Peer, libp2p_swarm:network_id(TID)) andalso
          libp2p_peer:is_stale(Peer, timer:minutes(TimeDiffMinutes)) of
         false ->

--- a/src/relay/libp2p_relay.erl
+++ b/src/relay/libp2p_relay.erl
@@ -13,8 +13,7 @@
     version/0,
     add_stream_handler/1,
     dial_framed_stream/3,
-    p2p_circuit/1, p2p_circuit/2, is_p2p_circuit/1,
-    is_valid_peer/2
+    p2p_circuit/1, p2p_circuit/2, is_p2p_circuit/1
 ]).
 
 -ifdef(TEST).
@@ -101,20 +100,6 @@ is_p2p_circuit(Address) ->
     case string:find(Address, ?P2P_CIRCUIT) of
         nomatch -> false;
         _ -> true
-    end.
-
--spec is_valid_peer(pid(), libp2p_crypto:pubkey_bin()) -> {error, any()} | boolean().
-is_valid_peer(Swarm, PubKeyBin) ->
-    PeerBook = libp2p_swarm:peerbook(Swarm),
-    case libp2p_peerbook:get(PeerBook, PubKeyBin) of
-        {error, _Reason}=Error ->
-            Error;
-        {ok, Peer} ->
-            StaleTime = libp2p_peerbook:stale_time(PeerBook),
-            ConnectedPeers = libp2p_peer:connected_peers(Peer),
-            not libp2p_peer:is_stale(Peer, StaleTime) andalso
-            libp2p_peer:has_public_ip(Peer) andalso
-            lists:member(libp2p_swarm:pubkey_bin(Swarm), ConnectedPeers)
     end.
 
 %% ------------------------------------------------------------------

--- a/test/relay_SUITE.erl
+++ b/test/relay_SUITE.erl
@@ -133,7 +133,6 @@ basic(_Config) ->
             meck:passthrough([S, A, O])
         end
     ),
-    meck:expect(libp2p_relay, is_valid_peer, fun(_, _) -> true end),
 
     % NAT fails so init relay on A manually
     ok = libp2p_relay:init(ASwarm),


### PR DESCRIPTION
- don't disconnect a relay until a ping actually fails
- relax arp throttle
- relax arp staleness criterion
- don't use connected peers in relaying