### PR TITLE
don't crash the nat server on bad cache insert

### DIFF
--- a/src/libp2p_cache.erl
+++ b/src/libp2p_cache.erl
@@ -51,7 +51,7 @@ reg_name(TID)->
 %%--------------------------------------------------------------------
 -spec insert(pid(), any(), any()) -> ok | {error, any()}.
 insert(Pid, Key, Value) ->
-    gen_server:call(Pid, {insert, Key, Value}).
+    gen_server:call(Pid, {insert, Key, Value}, 30000).
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -193,7 +193,10 @@ delete_mapping(IntPort, ExtPort) ->
 -spec update_cache(ets:tab(), non_neg_integer()) -> ok.
 update_cache(TID, Port) ->
     Cache = libp2p_swarm:cache(TID),
-    ok = libp2p_cache:insert(Cache, ?CACHE_KEY, Port).
+    spawn(fun() ->
+                  ok = libp2p_cache:insert(Cache, ?CACHE_KEY, Port)
+          end),
+    ok.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -144,11 +144,13 @@ terminate(_Reason, _State) ->
 -spec get_port_from_cache(ets:tab(), non_neg_integer()) -> non_neg_integer().
 get_port_from_cache(TID, IntPort) ->
     Cache = libp2p_swarm:cache(TID),
-    case libp2p_cache:lookup(Cache, ?CACHE_KEY) of
+    try libp2p_cache:lookup(Cache, ?CACHE_KEY) of
         undefined -> IntPort;
         P ->
             lager:info("got port from cache ~p", [P]),
             P
+    catch _:_ ->
+            IntPort
     end.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
having some issues where we can't insert to the cache for whatever reason and the nat ever restarts until the node restarts.  this gives the cache write more time to complete, and makes it so that the nat server doesn't care about the outcome.