### PR TITLE
Track group workers by ref, not pid, so restarts can be handled

### DIFF
--- a/src/group/libp2p_group_server.erl
+++ b/src/group/libp2p_group_server.erl
@@ -1,10 +1,10 @@
 -module(libp2p_group_server).
 
--export([request_target/3, send_result/3, send_ready/4]).
+-export([request_target/4, send_result/3, send_ready/4]).
 
--spec request_target(Server::pid(), term(), Worker::pid()) -> ok.
-request_target(Pid, Kind, WorkerPid) ->
-    gen_server:cast(Pid, {request_target, Kind, WorkerPid}).
+-spec request_target(Server::pid(), term(), Worker::pid(), Ref::reference()) -> ok.
+request_target(Pid, Kind, WorkerPid, Ref) ->
+    gen_server:cast(Pid, {request_target, Kind, WorkerPid, Ref}).
 
 -spec send_result(Server::pid(), Ref::term(), Result::any()) -> ok.
 send_result(Pid, Ref, Result) ->


### PR DESCRIPTION
The current gossip server was only tracking workers by pid, which means
if they crashed the supervisor would restart them, but the gossip server
would not notice they'd been restarted. This would prevent those gossip
connections from being sent outbound messages and degrade the gossip
group. This PR instead tracks the gossip workers by their Ref, which is
is in the supervision spec, so the restarted process will have the same
Ref.