### PR TITLE
Support for compressing streams

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,3 +4,5 @@ steps:
     name: ":hammer: build"
     agents:
       queue: "erlang"
+    artifact_paths:
+      - "artifacts/*"

--- a/src/group/gossip.hrl
+++ b/src/group/gossip.hrl
@@ -1,0 +1,4 @@
+-define(GROUP_PATH_V1, "gossip/1.0.0").
+-define(GROUP_PATH_V2, "gossip/1.0.2").
+-define(GROUP_DEFAULT_PATH, ?GROUP_PATH_V1).
+-define(SUPPORTED_GOSSIP_PATHS, [?GROUP_PATH_V2, ?GROUP_PATH_V1]).

--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -60,7 +60,7 @@ init(server, Connection, [Path, AckModule, AckState | _]) ->
                           [error_logger_lager_h:format_reason(Exit)]),
             {stop, normal}
     end;
-init(client, Connection, [AckRef, AckModule, AckState | _]) ->
+init(client, Connection, [_Path, AckRef, AckModule, AckState | _]) ->
     libp2p_connection:set_idle_timeout(Connection, ?ACK_STREAM_TIMEOUT),
     {ok, #state{connection=Connection,
                 ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}}.

--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -79,7 +79,7 @@ handle_data(_, Data, State=#state{handler_module=HandlerModule,
                                   path=Path}) ->
     #libp2p_gossip_frame_pb{key=Key, data=Bin} =
         libp2p_gossip_pb:decode_msg(Data, libp2p_gossip_frame_pb),
-    lager:debug("gossip received via path ~p: ~p",[Path, Bin]),
+    lager:debug("gossip received for handler ~p and key ~p via path ~p with payload ~p",[HandlerModule, Key, Path, Bin]),
     ok = HandlerModule:handle_data(HandlerState, self(), Key, apply_path_decode(Path, Bin)),
     {noreply, State}.
 

--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -1,5 +1,6 @@
 -module(libp2p_gossip_stream).
 
+-include("gossip.hrl").
 -include("pb/libp2p_gossip_pb.hrl").
 
 -behavior(libp2p_framed_stream).
@@ -7,10 +8,11 @@
 -callback handle_data(State::any(), StreamPid::pid(), Key::string(), Msg::binary()) -> ok.
 -callback accept_stream(State::any(),
                         Session::pid(),
-                        Stream::pid()) -> ok | {error, term()}.
+                        Stream::pid(),
+                        Path::string()) -> ok | {error, term()}.
 
 %% API
--export([encode/2]).
+-export([encode/2, encode/3]).
 %% libp2p_framed_stream
 -export([server/4, client/2, init/3, handle_data/3]).
 
@@ -18,13 +20,21 @@
 -record(state,
         { connection :: libp2p_connection:connection(),
           handler_module :: atom(),
-          handler_state :: any()
+          handler_state :: any(),
+          path :: any()
         }).
 
 %% API
 %%
 encode(Key, Data) ->
+    %% replies are routed via encode/2 from the gossip server
+    lager:debug("gossip encoding, no path: ~p",[]),
     Msg = #libp2p_gossip_frame_pb{key=Key, data=Data},
+    libp2p_gossip_pb:encode_msg(Msg).
+
+encode(Key, Data, Path) ->
+    lager:debug("gossip encoding for path: ~p",[Path]),
+    Msg = #libp2p_gossip_frame_pb{key=Key, data=apply_path_encode(Path, Data)},
     libp2p_gossip_pb:encode_msg(Msg).
 
 %% libp2p_framed_stream
@@ -35,16 +45,18 @@ client(Connection, Args) ->
 server(Connection, _Path, _TID, Args) ->
     libp2p_framed_stream:server(?MODULE, Connection, Args).
 
-init(server, Connection, [HandlerModule, HandlerState]) ->
+init(server, Connection, [Path, HandlerModule, HandlerState]) ->
+    lager:debug("initiating server with path ~p", [Path]),
     {ok, Session} = libp2p_connection:session(Connection),
     %% Catch errors from the handler module in accepting a stream. The
     %% most common occurence is during shutdown of a swarm where
     %% ordering of the shutdown will cause the accept below to crash
     %% noisily in the logs. This catch avoids that noise
-    case (catch HandlerModule:accept_stream(HandlerState, Session, self())) of
+    case (catch HandlerModule:accept_stream(HandlerState, Session, self(), Path)) of
         ok -> {ok, #state{connection=Connection,
                           handler_module=HandlerModule,
-                          handler_state=HandlerState}};
+                          handler_state=HandlerState,
+                          path=Path}};
         {error, too_many} ->
             {stop, normal};
         {error, Reason} ->
@@ -55,15 +67,39 @@ init(server, Connection, [HandlerModule, HandlerState]) ->
                           [error_logger_lager_h:format_reason(Exit)]),
             {stop, normal}
     end;
-init(client, Connection, [HandlerModule, HandlerState]) ->
+init(client, Connection, [Path, HandlerModule, HandlerState]) ->
+    lager:debug("initiating client with path ~p", [Path]),
     {ok, #state{connection=Connection,
                 handler_module=HandlerModule,
-                handler_state=HandlerState}}.
+                handler_state=HandlerState,
+                path=Path}}.
 
 handle_data(_, Data, State=#state{handler_module=HandlerModule,
-                                  handler_state=HandlerState}) ->
+                                  handler_state=HandlerState,
+                                  path=Path}) ->
     #libp2p_gossip_frame_pb{key=Key, data=Bin} =
         libp2p_gossip_pb:decode_msg(Data, libp2p_gossip_frame_pb),
-
-    ok = HandlerModule:handle_data(HandlerState, self(), Key, Bin),
+    lager:debug("gossip received via path ~p: ~p",[Path, Bin]),
+    ok = HandlerModule:handle_data(HandlerState, self(), Key, apply_path_decode(Path, Bin)),
     {noreply, State}.
+
+
+apply_path_encode(?GROUP_PATH_V1, Data)->
+    lager:debug("not compressing for path ~p..",[?GROUP_PATH_V1]),
+    Data;
+apply_path_encode(?GROUP_PATH_V2, Data)->
+    lager:debug("compressing for path ~p..",[?GROUP_PATH_V2]),
+    zlib:compress(Data);
+apply_path_encode(_UnknownPath, Data)->
+    lager:debug("not compressing for path ~p..",[_UnknownPath]),
+    Data.
+apply_path_decode(?GROUP_PATH_V1, Data)->
+    lager:debug("not decompressing for path ~p..",[?GROUP_PATH_V1]),
+    Data;
+apply_path_decode(?GROUP_PATH_V2, Data)->
+    lager:debug("decompressing for path ~p..",[?GROUP_PATH_V2]),
+    zlib:uncompress(Data);
+apply_path_decode(_UnknownPath, Data)->
+    lager:debug("not decompressing for path ~p..",[_UnknownPath]),
+    Data.
+

--- a/src/group/libp2p_group_gossip.erl
+++ b/src/group/libp2p_group_gossip.erl
@@ -12,7 +12,7 @@
 
 -export_type([handler/0, connection_kind/0]).
 
--export([add_handler/3, remove_handler/2, send/3, connected_addrs/2]).
+-export([add_handler/3, remove_handler/2, send/3, connected_addrs/2, connected_pids/2]).
 
 -spec add_handler(pid(), string(), handler()) -> ok.
 add_handler(Pid, Key, Handler) ->
@@ -29,6 +29,10 @@ remove_handler(Pid, Key) ->
 send(Pid, Key, Data) when is_list(Key), is_binary(Data) orelse is_function(Data) ->
     gen_server:cast(Pid, {send, Key, Data}).
 
--spec connected_addrs(pid(), connection_kind() | all) -> [{MAddr::string(), Pid::pid()}].
+-spec connected_addrs(pid(), connection_kind() | all) -> [MAddr::string()].
 connected_addrs(Pid, WorkerKind) ->
     gen_server:call(Pid, {connected_addrs, WorkerKind}, infinity).
+
+-spec connected_pids(Pid::pid(), connection_kind() | all) -> [pid()].
+connected_pids(Pid, WorkerKind) ->
+    gen_server:call(Pid, {connected_pids, WorkerKind}, infinity).

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -192,7 +192,7 @@ handle_cast({send, Key, Data}, State=#state{}) ->
                           libp2p_group_worker:send(Pid, Key, Data, true)
                   end, Pids),
     {noreply, State};
-handle_cast({send_ready, _target, _Ref, false}, State=#state{}) ->
+handle_cast({send_ready, _Target, _Ref, false}, State=#state{}) ->
     %% Ignore any not ready messages from group workers. The gossip
     %% server only reacts to ready messages by sending initial
     %% gossip_data.

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -3,12 +3,14 @@
 -behaviour(gen_server).
 -behavior(libp2p_gossip_stream).
 
+-include("gossip.hrl").
+
 %% API
 -export([start_link/2]).
 %% gen_server
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 %% libp2p_gossip_stream
--export([accept_stream/3, handle_data/4]).
+-export([accept_stream/4, handle_data/4]).
 
 -record(worker,
        { target :: string() | undefined,
@@ -27,7 +29,8 @@
          workers=[] :: [#worker{}],
          handlers=#{} :: #{string() => libp2p_group_gossip:handler()},
          drop_timeout :: pos_integer(),
-         drop_timer :: reference()
+         drop_timer :: reference(),
+         supported_paths :: [string()]
        }).
 
 -define(DEFAULT_PEERBOOK_CONNECTIONS, 5).
@@ -35,7 +38,6 @@
 -define(DEFAULT_MAX_INBOUND_CONNECTIONS, 10).
 -define(DEFAULT_DROP_TIMEOUT, 5 * 60 * 1000).
 -define(GROUP_ID, "gossip").
--define(GROUP_PATH, "gossip/1.0.0").
 
 %% API
 %%
@@ -60,8 +62,8 @@ handle_data(Pid, StreamPid, Key, Bin) ->
         end,
     gen_server:cast(Pid, {handle_data, StreamPid, Key, ListOrData}).
 
-accept_stream(Pid, SessionPid, StreamPid) ->
-    gen_server:call(Pid, {accept_stream, SessionPid, StreamPid}).
+accept_stream(Pid, SessionPid, StreamPid, Path) ->
+    gen_server:call(Pid, {accept_stream, SessionPid, StreamPid, Path}).
 
 
 %% gen_server
@@ -82,6 +84,8 @@ init([Sup, TID]) ->
         end,
     InboundCount = get_opt(Opts, inbound_connections, ?DEFAULT_MAX_INBOUND_CONNECTIONS),
     DropTimeOut = get_opt(Opts, drop_timeout, ?DEFAULT_DROP_TIMEOUT),
+    SupportedPaths = get_opt(Opts, supported_gossip_paths, ?SUPPORTED_GOSSIP_PATHS),
+    lager:debug("Supported gossip paths: ~p:", [SupportedPaths]),
 
     self() ! start_workers,
     {ok, update_metadata(#state{sup=Sup, tid=TID,
@@ -90,16 +94,21 @@ init([Sup, TID]) ->
                                 peerbook_connections=PeerBookCount,
                                 seednode_connections=SeedNodeCount,
                                 drop_timeout=DropTimeOut,
-                                drop_timer=schedule_drop_timer(DropTimeOut)})}.
+                                drop_timer=schedule_drop_timer(DropTimeOut),
+                                supported_paths=SupportedPaths})}.
 
-handle_call({accept_stream, _Session, _StreamPid}, _From, State=#state{workers=[]}) ->
-    {reply, {error, not_ready}, State};
-handle_call({accept_stream, Session, StreamPid}, From, State=#state{}) ->
-    libp2p_session:identify(Session, self(), {From, StreamPid}),
+handle_call({accept_stream, _Session, _StreamPid, _Path}, _From, State=#state{workers=[]}) ->
+    {reply, {error, not_ready}, State#state{}};
+handle_call({accept_stream, Session, StreamPid, Path}, From, State=#state{}) ->
+    libp2p_session:identify(Session, self(), {From, StreamPid, Path}),
     {noreply, State};
 handle_call({connected_addrs, Kind}, _From, State=#state{}) ->
     {Addrs, _Pids} = lists:unzip(connections(Kind, State)),
     {reply, Addrs, State};
+handle_call({connected_pids, Kind}, _From, State=#state{}) ->
+    {_Addrs, Pids} = lists:unzip(connections(Kind, State)),
+    {reply, Pids, State};
+
 handle_call({remove_handler, Key}, _From, State=#state{handlers=Handlers}) ->
     {reply, ok, State#state{handlers=maps:remove(Key, Handlers)}};
 
@@ -118,6 +127,8 @@ handle_cast({handle_data, StreamPid, Key, ListOrData}, State=#state{}) ->
             try M:handle_gossip_data(StreamPid, ListOrData, S) of
                 {reply, Reply} ->
                     %% handler wants to reply
+                    %% NOTE - This routes direct via libp2p_framed_stream:send/2 and not via the group worker
+                    %%        As such we need to encode at this point, and send raw..no encoding actions
                     case (catch libp2p_gossip_stream:encode(Key, Reply)) of
                         {'EXIT', Error} ->
                             lager:warning("Error encoding gossip data ~p", [Error]);
@@ -147,6 +158,7 @@ handle_cast({request_target, peerbook, WorkerPid, Ref}, State=#state{tid=TID}) -
                            {Addr, _} ->
                                [Addr];
                            false ->
+                               lager:debug("cannot get target as no peers or already connected to all peers",[]),
                                []
                        catch _:_ ->
                                  []
@@ -169,27 +181,16 @@ handle_cast({send, Key, Fun}, State=#state{}) when is_function(Fun, 0) ->
                           Data = Fun(),
                           %% Catch errors encoding the given arguments to avoid a bad key or
                           %% value taking down the gossip server
-                          case (catch libp2p_gossip_stream:encode(Key, Data)) of
-                              {'EXIT', Error} ->
-                                  lager:warning("Error encoding gossip data ~p", [Error]);
-                              Msg ->
-                                  libp2p_group_worker:send(Pid, Key, Msg)
-                          end
+                          libp2p_group_worker:send(Pid, Key, Data, true)
                   end, Pids),
     {noreply, State};
 
 handle_cast({send, Key, Data}, State=#state{}) ->
     {_, Pids} = lists:unzip(connections(all, State)),
-    %% Catch errors encoding the given arguments to avoid a bad key or
-    %% value taking down the gossip server
-    case (catch libp2p_gossip_stream:encode(Key, Data)) of
-        {'EXIT', Error} ->
-            lager:warning("Error encoding gossip data ~p", [Error]);
-        Msg ->
-            lists:foreach(fun(Pid) ->
-                                  libp2p_group_worker:send(Pid, Key, Msg)
-                          end, Pids)
-    end,
+    lager:debug("sending data via connection pids: ~p",[Pids]),
+    lists:foreach(fun(Pid) ->
+                          libp2p_group_worker:send(Pid, Key, Data, true)
+                  end, Pids),
     {noreply, State};
 handle_cast({send_ready, _target, _Ref, false}, State=#state{}) ->
     %% Ignore any not ready messages from group workers. The gossip
@@ -206,9 +207,8 @@ handle_cast({send_ready, Target, _Ref, _Ready}, State=#state{}) ->
                                                  Acc#state{handlers=maps:remove(Key, Acc#state.handlers)};
                                              ok ->
                                                  Acc;
-                                             {send, Data} ->
-                                                 Msg = libp2p_gossip_stream:encode(Key, Data),
-                                                 libp2p_group_worker:send(WorkerPid, send_ready, Msg),
+                                             {send, Msg} ->
+                                                 libp2p_group_worker:send(WorkerPid, send_ready, Msg, true),
                                                  Acc
                                          end
                                  end, State, State#state.handlers),
@@ -222,11 +222,17 @@ handle_cast(Msg, State) ->
     lager:warning("Unhandled cast: ~p", [Msg]),
     {noreply, State}.
 
-handle_info(start_workers, State=#state{tid=TID, seednode_connections=SeedCount, peerbook_connections=PeerCount}) ->
+handle_info(start_workers, State=#state{tid=TID, seednode_connections=SeedCount,
+                                        peerbook_connections=PeerCount,
+                                        supported_paths = SupportedPaths}) ->
     PeerBookWorkers = [start_worker(peerbook, State) || _ <- lists:seq(1, PeerCount)],
     SeedWorkers = [start_worker(seed, State) || _ <- lists:seq(1, SeedCount)],
-    libp2p_swarm:add_stream_handler(TID, ?GROUP_PATH,
-                                    {libp2p_gossip_stream, server, [?MODULE, self()]}),
+
+    GossipAddFun = fun(Path) ->
+                        libp2p_swarm:add_stream_handler(TID, Path,
+                                                        {libp2p_gossip_stream, server, [Path, ?MODULE, self()]})
+                   end,
+    lists:foreach(GossipAddFun, SupportedPaths),
     {noreply, State#state{workers=SeedWorkers ++ PeerBookWorkers}};
 handle_info(drop_timeout, State=#state{drop_timeout=DropTimeOut, drop_timer=DropTimer,
                                        workers=Workers}) ->
@@ -238,11 +244,11 @@ handle_info(drop_timeout, State=#state{drop_timeout=DropTimeOut, drop_timer=Drop
             lager:debug("Timeout dropping 1 connection: ~p]", [Worker#worker.target]),
             {noreply, drop_target(Worker, State#state{drop_timer=schedule_drop_timer(DropTimeOut)})}
     end;
-handle_info({handle_identify, {From, StreamPid}, {error, Error}}, State=#state{}) ->
+handle_info({handle_identify, {From, StreamPid, _Path}, {error, Error}}, State=#state{}) ->
     lager:notice("Failed to identify stream ~p: ~p", [StreamPid, Error]),
     gen_server:reply(From, {error, Error}),
     {noreply, State};
-handle_info({handle_identify, {From, StreamPid}, {ok, Identify}}, State=#state{}) ->
+handle_info({handle_identify, {From, StreamPid, Path}, {ok, Identify}}, State=#state{}) ->
     Target = libp2p_crypto:pubkey_bin_to_p2p(libp2p_identify:pubkey_bin(Identify)),
     %% Check if we already have a worker for this target
     case lookup_worker(Target, #worker.target, State) of
@@ -256,14 +262,14 @@ handle_info({handle_identify, {From, StreamPid}, {ok, Identify}}, State=#state{}
                     gen_server:reply(From, {error, too_many}),
                     {noreply, State};
                 false ->
-                    NewWorkers = [start_inbound_worker(Target, StreamPid, State) | State#state.workers],
+                    NewWorkers = [start_inbound_worker(Target, StreamPid, Path, State) | State#state.workers],
                     gen_server:reply(From, ok),
                     {noreply, State#state{workers=NewWorkers}}
             end;
         %% There's an existing worker for the given address, re-assign
         %% the worker the new stream.
         #worker{pid=Worker} ->
-            libp2p_group_worker:assign_stream(Worker, StreamPid),
+            libp2p_group_worker:assign_stream(Worker, StreamPid, Path),
             gen_server:reply(From, ok),
             {noreply, State}
     end;
@@ -272,10 +278,12 @@ handle_info(Msg, State) ->
     {noreply, State}.
 
 
-terminate(_Reason, #state{tid=TID}) ->
-    libp2p_swarm:remove_stream_handler(TID, ?GROUP_PATH).
-
-
+terminate(_Reason, #state{tid=TID, supported_paths = SupportedPaths}) ->
+    GossipAddFun = fun(Path) ->
+                        libp2p_swarm:remove_stream_handler(TID, Path)
+                   end,
+    lists:foreach(GossipAddFun, SupportedPaths),
+    ok.
 
 %% Internal
 %%
@@ -298,7 +306,7 @@ connections(Kind, #state{workers=Workers}) ->
                         Acc
                 end, [], Workers).
 
-assign_target(WorkerPid, WorkerRef, TargetAddrs, State=#state{workers=Workers}) ->
+assign_target(WorkerPid, WorkerRef, TargetAddrs, State=#state{workers=Workers, supported_paths = SupportedPaths}) ->
     case length(TargetAddrs) of
         0 ->
             %% the ref is stable across restarts, so use that as the lookup key
@@ -306,7 +314,7 @@ assign_target(WorkerPid, WorkerRef, TargetAddrs, State=#state{workers=Workers}) 
                 Worker=#worker{kind=seed, target=SelectedAddr, pid=StoredWorkerPid} when SelectedAddr /= undefined ->
                     %% don't give up on the seed nodes in case we're entirely offline
                     %% we need at least one connection to bootstrap the swarm
-                    ClientSpec = {?GROUP_PATH, {libp2p_gossip_stream, [?MODULE, self()]}},
+                    ClientSpec = {SupportedPaths, {libp2p_gossip_stream, [?MODULE, self()]}},
                     libp2p_group_worker:assign_target(WorkerPid, {SelectedAddr, ClientSpec}),
                     %% check if this worker got restarted
                     case WorkerPid /= StoredWorkerPid of
@@ -322,7 +330,7 @@ assign_target(WorkerPid, WorkerRef, TargetAddrs, State=#state{workers=Workers}) 
             end;
         _ ->
             SelectedAddr = mk_multiaddr(lists:nth(rand:uniform(length(TargetAddrs)), TargetAddrs)),
-            ClientSpec = {?GROUP_PATH, {libp2p_gossip_stream, [?MODULE, self()]}},
+            ClientSpec = {SupportedPaths, {libp2p_gossip_stream, [?MODULE, self()]}},
             libp2p_group_worker:assign_target(WorkerPid, {SelectedAddr, ClientSpec}),
             %% the ref is stable across restarts, so use that as the lookup key
             case lookup_worker(WorkerRef, #worker.ref, State) of
@@ -354,15 +362,15 @@ count_workers(Kind, #state{workers=Workers}) ->
                                   end, Workers),
     length(FilteredWorkers).
 
--spec start_inbound_worker(string(), pid(), #state{}) ->  #worker{}.
-start_inbound_worker(Target, StreamPid, #state{tid=TID, sup=Sup}) ->
+-spec start_inbound_worker(string(), pid(), string(), #state{}) ->  #worker{}.
+start_inbound_worker(Target, StreamPid, Path, #state{tid=TID, sup=Sup}) ->
     WorkerSup = libp2p_group_gossip_sup:workers(Sup),
     Ref = make_ref(),
     {ok, WorkerPid} = supervisor:start_child(
                         WorkerSup,
                         #{ id => Ref,
                            start => {libp2p_group_worker, start_link,
-                                     [Ref, inbound, StreamPid, self(), ?GROUP_ID, TID]},
+                                     [Ref, inbound, StreamPid, self(), ?GROUP_ID, TID, Path]},
                            restart => temporary
                          }),
     #worker{kind=inbound, pid=WorkerPid, target=Target, ref=Ref}.

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -208,7 +208,7 @@ handle_cast({send_ready, Target, _Ref, _Ready}, State=#state{}) ->
                                              ok ->
                                                  Acc;
                                              {send, Msg} ->
-                                                 libp2p_group_worker:send(WorkerPid, send_ready, Msg, true),
+                                                 libp2p_group_worker:send(WorkerPid, Key, Msg, true),
                                                  Acc
                                          end
                                  end, State, State#state.handlers),

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -208,7 +208,7 @@ handle_cast({request_target, Index, WorkerPid, _WorkerRef}, State=#state{tid=TID
                end,
     Path = lists:flatten([?GROUP_PATH_BASE, State#state.group_id, "/",
                           libp2p_crypto:bin_to_b58(libp2p_swarm:pubkey_bin(TID))]),
-    ClientSpec = {Path, {libp2p_ack_stream, [Index, ?MODULE, self(),
+    ClientSpec = {[Path], {libp2p_ack_stream, [Index, ?MODULE, self(),
                                              {secured, libp2p_swarm:swarm(TID)},
                                              {keys, State#state.group_keys}]}},
     libp2p_group_worker:assign_target(WorkerPid, {Target, ClientSpec}),
@@ -476,7 +476,7 @@ take_while([Worker | Workers], State) ->
             take_while(Workers, update_worker(Worker#worker{last_take=not_found}, State#state{store = NewRelcast}));
         {ok, Msgs, Acks, NewRelcast} ->
             %% lager:info("take ~p got ~p", [Index, length(Msgs)]),
-            libp2p_group_worker:send(Worker#worker.pid, Index, Msgs),
+            libp2p_group_worker:send(Worker#worker.pid, Index, Msgs, false),
             dispatch_acks(Acks, false, State),
             InFlight = relcast:in_flight(Index, NewRelcast),
             NewWorker = Worker#worker{in_flight=InFlight, last_take=ok},

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -56,8 +56,10 @@ handle_info({handle_identify, Session, {ok, Identify}}, State=#state{tid=TID}) -
     %%
     %% Store the session in config and tell the peerbook about the
     %% session change as well as the new identify record.
+    Addr = libp2p_crypto:pubkey_bin_to_p2p(libp2p_identify:pubkey_bin(Identify)),
+    lager:debug("received identity for peer ~p. Putting this peer", [Addr]),
     libp2p_config:insert_session(TID,
-                                 libp2p_crypto:pubkey_bin_to_p2p(libp2p_identify:pubkey_bin(Identify)),
+                                 Addr,
                                  Session),
     PeerBook = libp2p_swarm:peerbook(TID),
     libp2p_peerbook:register_session(PeerBook, Session, Identify),

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -16,7 +16,7 @@ setup_swarms(HandleDataResponse, Config) ->
     libp2p_swarm:add_stream_handler(S2, "serve_ack_frame",
                                     {libp2p_ack_stream, server, [?MODULE, {self(), HandleDataResponse}]}),
     Connection = test_util:dial(S1, S2, "serve_ack_frame"),
-    {ok, Stream} = libp2p_ack_stream:client(Connection, [client, ?MODULE, self()]),
+    {ok, Stream} = libp2p_ack_stream:client(Connection, [undefined, client, ?MODULE, self()]),
     [{swarms, Swarms}, {client, Stream} | Config].
 
 init_per_testcase(ack_test=TestCase, Config) ->

--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -7,6 +7,8 @@
 
 -export([all/0, init_per_testcase/2, end_per_testcase/2]).
 -export([connection_test/1, gossip_test/1, seed_test/1]).
+-export([forwards_compat_gossip_test/1, backwards_compat_gossip_test/1]).
+-export([same_path_gossip_test1/1, same_path_gossip_test2/1]).
 -export([init_gossip_data/1, handle_gossip_data/3]).
 
 all() ->
@@ -14,6 +16,10 @@ all() ->
       connection_test
     , gossip_test
     , seed_test
+    , backwards_compat_gossip_test
+    , forwards_compat_gossip_test
+    , same_path_gossip_test1
+    , same_path_gossip_test2
     ].
 
 
@@ -36,6 +42,15 @@ init_per_testcase(seed_test = TestCase, Config) ->
                                        {base_dir, ?config(base_dir, Config0)}
                                      ]),
     [{swarms, [S1, S2]} | Config];
+
+
+init_per_testcase(TestCase, Config) when TestCase == forwards_compat_gossip_test;
+                                         TestCase ==  backwards_compat_gossip_test;
+                                         TestCase == same_path_gossip_test1;
+                                         TestCase == same_path_gossip_test2 ->
+
+    test_util:init_base_dir_config(?MODULE, TestCase, Config);
+
 init_per_testcase(TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
     Swarms = test_util:setup_swarms(2, [
@@ -46,6 +61,11 @@ init_per_testcase(TestCase, Config) ->
                                         {base_dir, ?config(base_dir, Config0)} ]),
     [{swarms, Swarms} | Config].
 
+end_per_testcase(_TestCase, _Config) when _TestCase == forwards_compat_gossip_test;
+                                         _TestCase ==  backwards_compat_gossip_test;
+                                         _TestCase == same_path_gossip_test1;
+                                         _TestCase == same_path_gossip_test2 ->
+    ok;
 end_per_testcase(_, Config) ->
     Swarms = ?config(swarms, Config),
     test_util:teardown_swarms(Swarms).
@@ -102,6 +122,7 @@ gossip_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     S2Group = libp2p_swarm:gossip_group(S2),
     libp2p_group_gossip:send(S2Group, "gossip_test", <<"hello">>),
@@ -112,6 +133,229 @@ gossip_test(Config) ->
     end,
 
     ok.
+
+
+forwards_compat_gossip_test(Config) ->
+    %% NOTE: declaring swarms in test here as the order of declaration matters
+    %% the first swarm declared will be the one to dial, so this test declares in the order it requires
+    %% keep the swarm declarations here until this is worked out
+    %% S1 ( gossip/1.0.0 ) will dial S2 ( gossip/1.0.2 / gossip/1.0.0 )
+    %% S1 will gossip to S2
+    [S1] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    [S2] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    timer:sleep(1000),
+
+    %% add handlers for S1
+    S1Group = libp2p_swarm:gossip_group(S1),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% add handlers for S2
+    S2Group = libp2p_swarm:gossip_group(S2),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.2", {?MODULE, self()}),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% connect the swarms and wait until they are fully ready
+    connect_await_ready(S1, S2),
+
+    %% send the msg from S1 to S2
+    libp2p_group_gossip:send(S1Group, "gossip/1.0.0", <<"hello S2, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S2, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    %% send the msg from S2 to S1
+    libp2p_group_gossip:send(S2Group, "gossip/1.0.0", <<"hello S1, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S1, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    test_util:teardown_swarms([S1,S2]),
+    ok.
+
+backwards_compat_gossip_test(Config) ->
+    %% NOTE: declaring swarms in test here as the order of declaration matters
+    %% the first swarm declared will be the one to dial, so this test declares in the order it requires
+    %% keep the swarm declarations here until this is worked out
+
+    %% S1 ( gossip/1.0.2 / gossip/1.0.0 ) will connect to S2 ( gossip/1.0.0 )
+    %% S1 will gossip to S2, gossip/1.0.0 will be the negotiated path
+
+    [S1] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+    %% S2 represents an old swarm, so dont specifiy the gossip protocol in the config let it use default
+    [S2] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    timer:sleep(1000),
+
+    %% add handlers for S1
+    S1Group = libp2p_swarm:gossip_group(S1),
+    ct:pal("S1 group: ~p", [S1Group]),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.2", {?MODULE, self()}),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.0", {?MODULE, self()}),
+
+
+    %% add handlers for S2
+    S2Group = libp2p_swarm:gossip_group(S2),
+    ct:pal("S2 group: ~p", [S2Group]),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% connect the swarms and wait until they are fully ready
+    connect_await_ready(S1, S2),
+
+    %% send the msg from S1 to S2
+    libp2p_group_gossip:send(S1Group, "gossip/1.0.0", <<"hello S2, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S2, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    %% send the msg from S2 to S1
+    libp2p_group_gossip:send(S2Group, "gossip/1.0.0", <<"hello S1, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S1, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    test_util:teardown_swarms([S1,S2]),
+    ok.
+
+
+same_path_gossip_test1(Config) ->
+    %% NOTE: declaring swarms in test here as the order of declaration matters
+    %% the first swarm declared will be the one to dial, so this test declares in the order it requires
+    %% keep the swarm declarations here until this is worked out
+    %% S1 ( gossip/1.0.0 ) will connect to S2 ( gossip/1.0.0 )
+    %% S2 will gossip to S3, gossip/1.0.0 will be the negotiated path
+
+    [S1] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    [S2] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    timer:sleep(1000),
+
+    %% add handlers for S1
+    S1Group = libp2p_swarm:gossip_group(S1),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% add handlers for S2
+    S2Group = libp2p_swarm:gossip_group(S2),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% connect the swarms and wait until they are fully ready
+    connect_await_ready(S1, S2),
+
+    %% send the msg from S1 to S2
+    libp2p_group_gossip:send(S1Group, "gossip/1.0.0", <<"hello S2, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S2, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    %% send the msg from S2 to S1
+    libp2p_group_gossip:send(S2Group, "gossip/1.0.0", <<"hello S1, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S1, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    test_util:teardown_swarms([S1,S2]),
+    ok.
+
+
+same_path_gossip_test2(Config) ->
+    %% NOTE: declaring swarms in test here as the order of declaration matters
+    %% the first swarm declared will be the one to dial, so this test declares in the order it requires
+    %% keep the swarm declarations here until this is worked out
+    %% S1 ( gossip/1.0.2 / gossip/1.0.0 ) will connect to S2 ( gossip/1.0.2 )
+    %% S2 will gossip to S1, gossip/1.0.2 will be the negotiated path
+
+    [S1] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+    [S2] = test_util:setup_swarms(1, [
+                                       {libp2p_group_gossip, [{peerbook_connections, 1},
+                                                              {peer_cache_timeout, 100},
+                                                              {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
+                                       {base_dir, ?config(base_dir, Config)}
+                                     ]),
+
+
+    timer:sleep(1000),
+
+    %% add handlers for S1
+    S1Group = libp2p_swarm:gossip_group(S1),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.2", {?MODULE, self()}),
+    libp2p_group_gossip:add_handler(S1Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% add handlers for S2
+    S2Group = libp2p_swarm:gossip_group(S2),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.2", {?MODULE, self()}),
+    libp2p_group_gossip:add_handler(S2Group, "gossip/1.0.0", {?MODULE, self()}),
+
+    %% connect the swarms and wait until they are fully ready
+    connect_await_ready(S1, S2),
+
+    %% send the msg from S1 to S2
+    libp2p_group_gossip:send(S1Group, "gossip/1.0.2", <<"hello S2, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S2, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    %% send the msg from S2 to S1
+    libp2p_group_gossip:send(S2Group, "gossip/1.0.2", <<"hello S1, its me you're looking for">>),
+
+    receive
+        {handle_gossip_data, <<"hello S1, its me you're looking for">>} -> ok
+    after 5000 -> error(timeout)
+    end,
+
+    test_util:teardown_swarms([S1,S2]),
+    ok.
+
 
 seed_test(Config) ->
     [S1, S2] = ?config(swarms, Config),
@@ -143,3 +387,15 @@ get_peer(Swarm) ->
     Addr = libp2p_swarm:pubkey_bin(Swarm),
     {ok, Peer} = libp2p_peerbook:get(PeerBook, Addr),
     Peer.
+
+connect_await_ready(S1, S2)->
+    %% setup peerbook entries for S1 to point to S2
+    S1PeerBook = libp2p_swarm:peerbook(S1),
+    libp2p_peerbook:put(S1PeerBook, [get_peer(S2)]),
+    %% Verify that S1 finds out about S2
+    ok = test_util:wait_until(fun() ->
+                                      libp2p_peerbook:is_key(S1PeerBook, libp2p_swarm:pubkey_bin(S2))
+                              end),
+    %% wait until we are fully connected
+    test_util:await_gossip_groups([S1, S2]),
+    test_util:await_gossip_streams([S1, S2]).

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -56,6 +56,7 @@ unicast_test(Config) ->
     test_util:connect_swarms(S1, S3),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -112,6 +113,7 @@ multicast_test(Config) ->
     test_util:connect_swarms(S1, S3),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -144,6 +146,7 @@ defer_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -185,6 +188,7 @@ close_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -228,6 +232,7 @@ pipeline_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:address(S) || S <- Swarms],
 


### PR DESCRIPTION
This provides support for compressing gossiped stream data ( blocks and peerbook ).  It leaves relcast as is, no changes other than some threading touchpoints as relcast shares the same group_worker.erl as gossip.

The compression has been added at the group/stream level as opposed to the higher level handlers  ( such as blockchain_gossip_handlers ) as its the group gossip protocol only which is involved in negotiation with the remote side.  The dialing of the remote peer takes place within the context of the group_worker and the path/protocol negotiated as part of the dial is that of group gossip, ie `gossip/1.0.0`.

To support the compression then, I have added support for `gossip/1.0.2`.  When a group worker dials a remote peer it will attempt to connect using its latest gossip protocol, if that fails it will move to the next until there is a match with the remote side.  If the negotiated protocol is 1.0.2 then compression is applied upon sending a msg and uncompression applied upon a receive by the remote peer.

Most of the other work relates to threading the negotiated protocol to the group worker and libp2p_gossip_stream.   Group worker needs to know the negotiated protocol as the encoding of msgs during a `send` takes place within its context, as such it needs to know the negotiated protocol to determine whether to compress the payload or not.

libp2p_gossip_stream then is supplied the negotiated protocol so that it can determine whether to uncompress the received payload when acting in server mode. 

Associated PRs:

https://github.com/helium/blockchain-core/pull/377
https://github.com/helium/miner/pull/329
