### PR TITLE
use named table for swarm ets

### DIFF
--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -286,7 +286,7 @@ add_connection_handler(TID, Key, {ServerMF, ClientMF}) ->
     libp2p_config:insert_connection_handler(TID, {Key, ServerMF, ClientMF}),
     ok.
 
--spec connect(pid(), string()) -> {ok, pid()} | {error, term()}.
+-spec connect(pid() | ets:tab(), string()) -> {ok, pid()} | {error, term()}.
 connect(Sup, Addr) ->
     connect(Sup, Addr, [], ?CONNECT_TIMEOUT).
 

--- a/src/libp2p_swarm_sup.erl
+++ b/src/libp2p_swarm_sup.erl
@@ -78,7 +78,7 @@ peerbook(TID) ->
 %%====================================================================
 init([Name, Opts]) ->
     inert:start(),
-    TID = ets:new(Name, [public, ordered_set, {read_concurrency, true}]),
+    TID = ets:new(Name, [public, ordered_set, named_table, {read_concurrency, true}]),
     ets:insert(TID, {?SUP, self()}),
     ets:insert(TID, {?NAME, Name}),
     ets:insert(TID, {?OPTS, Opts}),


### PR DESCRIPTION
By using named_table for the swarm ETS, the TID will always be the same as that of the swarm name. This provides the benefit that any process or component with access to the swarm name can access the ETS table without the need to perform sync calls to a process holding the ETS TID

Associated blockchain core PR: https://github.com/helium/blockchain-core/pull/442
Associated miner PR: https://github.com/helium/miner/pull/384