### PR TITLE
prevent peers both dialing each other 

### DIFF
--- a/src/group/libp2p_group_gossip.erl
+++ b/src/group/libp2p_group_gossip.erl
@@ -12,7 +12,7 @@
 
 -export_type([handler/0, connection_kind/0]).
 
--export([add_handler/3, remove_handler/2, send/3, connected_addrs/2]).
+-export([add_handler/3, remove_handler/2, send/3, connected_addrs/2, connected_pids/2]).
 
 -spec add_handler(pid(), string(), handler()) -> ok.
 add_handler(Pid, Key, Handler) ->
@@ -29,6 +29,10 @@ remove_handler(Pid, Key) ->
 send(Pid, Key, Data) when is_list(Key), is_binary(Data) orelse is_function(Data) ->
     gen_server:cast(Pid, {send, Key, Data}).
 
--spec connected_addrs(pid(), connection_kind() | all) -> [{MAddr::string(), Pid::pid()}].
+-spec connected_addrs(pid(), connection_kind() | all) -> [MAddr::string()].
 connected_addrs(Pid, WorkerKind) ->
     gen_server:call(Pid, {connected_addrs, WorkerKind}, infinity).
+
+-spec connected_pids(Pid::pid(), connection_kind() | all) -> [pid()].
+connected_pids(Pid, WorkerKind) ->
+    gen_server:call(Pid, {connected_pids, WorkerKind}, infinity).

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -100,6 +100,9 @@ handle_call({accept_stream, Session, StreamPid}, From, State=#state{}) ->
 handle_call({connected_addrs, Kind}, _From, State=#state{}) ->
     {Addrs, _Pids} = lists:unzip(connections(Kind, State)),
     {reply, Addrs, State};
+handle_call({connected_pids, Kind}, _From, State=#state{}) ->
+    {_Addrs, Pids} = lists:unzip(connections(Kind, State)),
+    {reply, Pids, State};
 handle_call({remove_handler, Key}, _From, State=#state{handlers=Handlers}) ->
     {reply, ok, State#state{handlers=maps:remove(Key, Handlers)}};
 

--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -136,6 +136,18 @@ handle_cast({add_handler, Key, Handler}, State=#state{handlers=Handlers}) ->
     {noreply, State#state{handlers=maps:put(Key, Handler, Handlers)}};
 handle_cast({request_target, inbound, WorkerPid, _Ref}, State=#state{}) ->
     {noreply, stop_inbound_worker(WorkerPid, State)};
+handle_cast({clear_target, _Kind, _WorkerPid, Ref}, State=#state{workers = Workers}) ->
+    lager:debug("clearing target for worker ~p ", [_WorkerPid]),
+    %% the ref is stable across restarts, so use that as the lookup key
+    case lookup_worker(Ref, #worker.ref, State) of
+        Worker=#worker{} ->
+            %% TODO - should the pid be set to undefined along with target ?
+            NewWorkers = lists:keyreplace(Ref, #worker.ref, Workers,
+                                          Worker#worker{target=undefined}),
+            State#state{workers=NewWorkers};
+        _ ->
+            State
+    end;
 handle_cast({request_target, peerbook, WorkerPid, Ref}, State=#state{tid=TID}) ->
     LocalAddr = libp2p_swarm:pubkey_bin(TID),
     PeerList = case libp2p_swarm:peerbook(TID) of
@@ -145,8 +157,10 @@ handle_cast({request_target, peerbook, WorkerPid, Ref}, State=#state{tid=TID}) -
                        WorkerAddrs = [ libp2p_crypto:p2p_to_pubkey_bin(W#worker.target) || W <- State#state.workers, W#worker.target /= undefined, W#worker.kind /= seed ],
                        try libp2p_peerbook:random(Peerbook, [LocalAddr|WorkerAddrs]) of
                            {Addr, _} ->
+                               lager:debug("found target ~p, assigning to worker ~p",[Addr, WorkerPid]),
                                [Addr];
                            false ->
+                               lager:debug("cannot get target as no peers or already connected to all peers",[]),
                                []
                        catch _:_ ->
                                  []

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -213,6 +213,18 @@ handle_cast({request_target, Index, WorkerPid, _WorkerRef}, State=#state{tid=TID
                                              {keys, State#state.group_keys}]}},
     libp2p_group_worker:assign_target(WorkerPid, {Target, ClientSpec}),
     {noreply, NewState};
+handle_cast({clear_target, _Kind, _WorkerPid, Ref}, State=#state{workers = Workers}) ->
+    lager:debug("clearing target for worker ~p ", [_WorkerPid]),
+    %% the ref is stable across restarts, so use that as the lookup key
+    case lookup_worker(Ref, #worker.ref, State) of
+        Worker=#worker{} ->
+            %% TODO - should the pid be set to undefined along with target ?
+            NewWorkers = lists:keyreplace(Ref, #worker.ref, Workers,
+                                          Worker#worker{target=undefined}),
+            State#state{workers=NewWorkers};
+        _ ->
+            State
+    end;
 handle_cast({handle_input, _Msg}, State=#state{close_state=closing}) ->
     {noreply, State};
 handle_cast({handle_input, _Msg}, State=#state{store=Bad}) when Bad == not_started orelse
@@ -386,7 +398,6 @@ terminate(Reason, #state{store=Store}) ->
 
 %% Internal
 %%
-
 -spec start_workers([string()], #state{}) -> [#worker{}].
 start_workers(TargetAddrs, #state{sup=Sup, group_id=GroupID, tid=TID, self_index=SelfIndex}) ->
     WorkerSup = libp2p_group_relcast_sup:workers(Sup),

--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -213,7 +213,7 @@ handle_cast({request_target, Index, WorkerPid, _WorkerRef}, State=#state{tid=TID
                                              {keys, State#state.group_keys}]}},
     libp2p_group_worker:assign_target(WorkerPid, {Target, ClientSpec}),
     {noreply, NewState};
-handle_cast({clear_target, _Kind, _WorkerPid, Ref}, State=#state{workers = Workers}) ->
+handle_cast({clear_target, _Index, _WorkerPid, Ref}, State=#state{workers = Workers}) ->
     lager:debug("clearing target for worker ~p ", [_WorkerPid]),
     %% the ref is stable across restarts, so use that as the lookup key
     case lookup_worker(Ref, #worker.ref, State) of

--- a/src/group/libp2p_group_server.erl
+++ b/src/group/libp2p_group_server.erl
@@ -1,10 +1,14 @@
 -module(libp2p_group_server).
 
--export([request_target/4, send_result/3, send_ready/4]).
+-export([request_target/4, clear_target/4, send_result/3, send_ready/4]).
 
 -spec request_target(Server::pid(), term(), Worker::pid(), Ref::reference()) -> ok.
 request_target(Pid, Kind, WorkerPid, Ref) ->
     gen_server:cast(Pid, {request_target, Kind, WorkerPid, Ref}).
+
+-spec clear_target(Server::pid(), term(), Worker::pid(), Ref::reference()) -> ok.
+clear_target(Pid, Kind, WorkerPid, Ref) ->
+    gen_server:cast(Pid, {clear_target, Kind, WorkerPid, Ref}).
 
 -spec send_result(Server::pid(), Ref::term(), Result::any()) -> ok.
 send_result(Pid, Ref, Result) ->

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -214,7 +214,7 @@ connecting(info, connect_retry_timeout, Data=#data{target={undefined, _}}) ->
     {next_state, targeting,
      cancel_connect_retry_timer(Data#data{connect_pid=kill_pid(Data#data.connect_pid)}),
      ?TRIGGER_TARGETING};
-connecting(info, connect_retry_timeout, Data=#data{tid=TID,
+connecting(info, connect_retry_timeout, Data=#data{tid=TID, kind=Kind,
                                                    target={MAddr, {Path, {M, A}}},
                                                    connect_pid=ConnectPid}) ->
     %% When the retry timeout fires we kill any exisitng connect_pid
@@ -241,7 +241,8 @@ connecting(info, connect_retry_timeout, Data=#data{tid=TID,
                 %% to avoid this we will only have one side perform the dialing based on a decision around data available on both ends
                 %% as such, we lexicographically compare the local peer addr with that of the remote peers addr
                 %% peer with highest order gets to do the stream dial
-                case LocalAddr > MAddr of
+                %% NOTE for relcast we always dial - relcast passes in an integer index as the Kind field, so if kind is an integer we always dial
+                case LocalAddr > MAddr orelse is_integer(Kind) of
                     true ->
                         lager:debug("(~p) peer ~p will dial a stream to remote peer ~p", [Parent, LocalAddr, MAddr]),
                         case libp2p_swarm:dial_framed_stream(TID, MAddr, Path, M, A) of

--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -102,6 +102,7 @@ gossip_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     S2Group = libp2p_swarm:gossip_group(S2),
     libp2p_group_gossip:send(S2Group, "gossip_test", <<"hello">>),

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -56,6 +56,7 @@ unicast_test(Config) ->
     test_util:connect_swarms(S1, S3),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -112,6 +113,7 @@ multicast_test(Config) ->
     test_util:connect_swarms(S1, S3),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -144,6 +146,7 @@ defer_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -185,6 +188,7 @@ close_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
 
@@ -228,6 +232,7 @@ pipeline_test(Config) ->
     test_util:connect_swarms(S1, S2),
 
     test_util:await_gossip_groups(Swarms),
+    test_util:await_gossip_streams(Swarms),
 
     Members = [libp2p_swarm:address(S) || S <- Swarms],
 

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -102,7 +102,7 @@ await_gossip_group(Swarm, Swarms) ->
       fun() ->
               GroupAddrs = sets:from_list(libp2p_group_gossip:connected_addrs(GossipGroup, all)),
               sets:is_subset(ExpectedAddrs, GroupAddrs)
-      end).
+      end, 50, 200).
 
 await_gossip_groups(Swarms) ->
     lists:foreach(fun(S) ->

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -6,7 +6,7 @@
 -define(BASE_TMP_DIR_TEMPLATE, "XXXXXXXXXX").
 
 -export([setup/0, setup_swarms/1, setup_swarms/2, teardown_swarms/1,
-         connect_swarms/2, disconnect_swarms/2, await_gossip_groups/1,
+         connect_swarms/2, disconnect_swarms/2, await_gossip_groups/1, await_gossip_streams/1,
          wait_until/1, wait_until/3, rm_rf/1, dial/3, dial_framed_stream/5, nonl/1,
          init_base_dir_config/3,
          tmp_dir/0, tmp_dir/1,
@@ -108,6 +108,23 @@ await_gossip_groups(Swarms) ->
     lists:foreach(fun(S) ->
                           ok = await_gossip_group(S, Swarms)
                   end, Swarms).
+
+await_gossip_streams(Swarms) when is_list(Swarms)->
+    lists:foreach(fun(S) ->
+                          ok = await_gossip_streams(S)
+                  end, Swarms);
+
+await_gossip_streams(Swarm) ->
+    GossipGroup = libp2p_swarm:gossip_group(Swarm),
+    GroupPids = libp2p_group_gossip:connected_pids(GossipGroup, all),
+    test_util:wait_until(
+      fun() ->
+              try
+                lists:all(fun(Pid)-> connected == erlang:element(1, sys:get_state(Pid)) end, GroupPids)
+              catch _:_ ->
+                 false
+              end
+      end, 400, 250).
 
 nonl([$\n|T]) -> nonl(T);
 nonl([H|T]) -> [H|nonl(T)];


### PR DESCRIPTION
This PR addresses two related problems:

**Problem Description 1**
----------
There is a race condition which can trigger after a _libp2p_swarm:connect/2_ is called.  As part of the connect call the identities of both peers are swapped and peerbook entries are added for the other on each peer.  

It is after the peerbook entries are added where the race can occur.  Each peer's group workers will request a target from the group server.  If they happen to do this at the same time  and be assigned each others as the target ( which in the tests can happen frequently ) the workers will dial a stream to each other.

This will result in two sets of streams being created on and for each of the two peers.  On each peer, when the second stream comes up it will be assigned to the same group worker as the first.  And as there is an existing stream, the _group_worker:handle_assign_stream/2_ function will flip a coin to determine which stream to keep.  As this happens on both peers, should both peers end up with opposite sides of the coin, it will result in both the first and the second streams being closed.  The peers are then left without any active streams to each other.

The reconnect logic will then kick in but in many cases we end up repeating the exact same scenario again after which the group worker will give up connecting/dialing and revert back to targeting.

**Observable impact on tests**

The exact extent of the observable behaviour is determined by how closely together the two sets of streams come up ( there could be network latency on one or both routes or  a swarm running slowly ).  If both peers dials result in streams being assigned in quick succession, the impact is mostly that the tests take longer to advance as they are held up at the _await_gossip_group_ and _await_gossip_streams_ handlers.  As the group workers have a back off and will ultimately revert to targeting after they exceed the connect retry limit, the _await*_ functions can timeout leading to test fails.

If one of the two dials take longer for the streams to be generated the impact on the tests is that they advance quickly past the _await*_ functions and start to exchange msgs via gossip using the first stream.  During this exchange the second stream can come up ( resulting in both streams being closed due to the peers getting opposite sides of the coin toss ) and the tests fail due to gossip msgs being lost.


**Problem Description 2**
----------
In the above scenario after both peers close the streams, the group workers will attempt to reconnect.  If the reconnect attempts result in the same scenario, ie both peers dialing each other, producing two streams, coin toss closing both streams...then the group workers will give up connecting/dialing and revert back to targeting.

At this point targeting will request a new target from the group sever.  However the previously assigned target peer will never be reassigned as the group server has not been told the original assign_target failed and as far as its concerned the target is assigned to a worker ( the group server marks a target as assigned to a worker as part of its assign_target call and does so before the group worker receives the target ).

When this happens the previously assigned peer will never be reassigned to a new group worker.

The observable impact of this via the tests is that the tests never advance beyond the _await_gossip_group_ or _await_gossip_streams_ functions.


Fix for problem 1
----------------
Prevent peers dialing streams to each other.  Assuming both peers are interconnected, only one peer will attempt to dial a stream.  The decision is based on the lexicographically order of both peer's p2p address.  Using the pubkeybin is also possible here.  I cannot use the identity for this decision as we have to account for the scenario whereby peer  A is gossipped new peer C from connected peer B.  Peer A is not connected with peer C and thus not in possession of its identity ( unless I am missing something such as being able to retrieve the identify from the peerbook ?...)

Fix for problem 2
----------------
The group worker, should the connect to the remote peer fail and it reverts to targeting, will now inform the group server the connect attempt failed and it will clear the target for that worker.  This will make the peer available again by the group server for targeting and will be assigned group workers upon subsequent request_target requests.

