### PR TITLE
make winner/loser stream close decision deterministic when sim dials occur between peers

### DIFF
--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -259,6 +259,7 @@ handle_info({handle_identify, {ReplyRef, StreamPid, Path}, {ok, Identify}}, Stat
         %% If not, we we check if we can accept a random inbound
         %% connection and start a worker for the inbound stream if ok
         false ->
+            lager:debug("received identity for non existing target ~p.  Stream: ~p",[Target, StreamPid]),
             case count_workers(inbound, State) > State#state.max_inbound_connections of
                 true ->
                     lager:debug("Too many inbound workers: ~p",
@@ -273,6 +274,7 @@ handle_info({handle_identify, {ReplyRef, StreamPid, Path}, {ok, Identify}}, Stat
         %% There's an existing worker for the given address, re-assign
         %% the worker the new stream.
         #worker{pid=Worker} ->
+            lager:debug("received identity for existing target ~p.  Stream: ~p",[Target, StreamPid]),
             libp2p_group_worker:assign_stream(Worker, StreamPid, Path),
             StreamPid ! {ReplyRef, ok},
             {noreply, State}

--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -389,13 +389,7 @@ get_peer(Swarm) ->
     Peer.
 
 connect_await_ready(S1, S2)->
-    %% setup peerbook entries for S1 to point to S2
-    S1PeerBook = libp2p_swarm:peerbook(S1),
-    libp2p_peerbook:put(S1PeerBook, [get_peer(S2)]),
-    %% Verify that S1 finds out about S2
-    ok = test_util:wait_until(fun() ->
-                                      libp2p_peerbook:is_key(S1PeerBook, libp2p_swarm:pubkey_bin(S2))
-                              end),
+    test_util:connect_swarms(S1, S2),
     %% wait until we are fully connected
     test_util:await_gossip_groups([S1, S2]),
     test_util:await_gossip_streams([S1, S2]).


### PR DESCRIPTION
NOTE: this supersedes https://github.com/helium/erlang-libp2p/pull/278

Related PR ( both issues affect same flow ): https://github.com/helium/erlang-libp2p/pull/282

There is a race condition which can trigger after a libp2p_swarm:connect/2 is called. As part of the connect call the identities of both peers are swapped and peerbook entries are added for the other on each peer.

It is after the peerbook entries are added where the race can occur. Each peer's group workers will request a target from the group server. If they happen to do this at the same time and be assigned each others as the target ( which in the tests can happen frequently ) the workers will dial a stream to each other.

This will result in two sets of streams being created on and for each of the two peers. On each peer, when the second stream comes up it will be assigned to the same group worker as the first. And as there is an existing stream, the group_worker:handle_assign_stream/2 function will flip a coin to determine which stream to keep. As this happens on both peers, should both peers end up with opposite sides of the coin, it will result in both the first and the second streams being closed. The peers are then left without any active streams to each other.

The reconnect logic will then kick in but in many cases we end up repeating the exact same scenario again after which the group worker will give up connecting/dialing and revert back to targeting.

_Observable impact on tests_

The exact extent of the observable behaviour is determined by how closely together the two sets of streams come up ( there could be network latency on one or both routes or a swarm running slowly ). If both peers dials result in streams being assigned in quick succession, the impact is mostly that the tests take longer to advance as they are held up at the _await_gossip_group_ and _await_gossip_streams_ handlers. As the group workers have a back off and will ultimately revert to targeting after they exceed the connect retry limit, the _await*_ functions can timeout leading to test fails.

If one of the two dials take longer for the streams to be generated the impact on the tests is that they advance quickly past the _await*_ functions and start to exchange msgs via gossip using the first stream. During this exchange the second stream can come up ( resulting in both streams being closed due to the peers getting opposite sides of the coin toss ) and the tests fail due to gossip msgs being lost.

**Implemented Solution**
The fix here is to replace the random coin toss with a process that is deterministic on both peers.  This is acheived by both peers choosing a winning stream based on the lexicographic order of their multi addrs.  The dial and associated stream of the peer with the higher ordered peer name will win, the other stream/dial will be closed

_NOTE:_
This solution in not without potential side effects, there remains potential for msgs to be lost.  For example if both peers simultaneously dial but one stream is taking longer to establish.  If, after the first stream is established, msgs start to be exchanged and then the second stream comes up it can result in the currently active stream on which those msgs are being exchanged being closed and msgs being lost mid flight.