### PR TITLE
Add missing proto occurrence field rule

### DIFF
--- a/src/relay/libp2p_relay.proto
+++ b/src/relay/libp2p_relay.proto
@@ -33,12 +33,12 @@ message relay_bridge_sc {
 
 // Ping-Pong message to detect connection failure
 message relay_ping {
-    uint32 seq = 1;
+    required uint32 seq = 1;
     enum Direction {
         PING = 1;
         PONG = 2;
     }
-    Direction direction = 2;
+    required Direction direction = 2;
 }
 
 message relay_envelope {


### PR DESCRIPTION
This protobuf file has mixed field definitions which was fine until more recent versions of the compiler.

```
===> compiling "/etl/_build/default/lib/libp2p/src/relay/libp2p_relay.proto" to "/etl/_build/default/lib/libp2p/src/pb/libp2p_relay_pb.erl"
===> opts: [{i,"/etl/_build/default/lib/libp2p/src"},
                   {o_erl,"/etl/_build/default/lib/libp2p/src/pb"},
                   {o_hrl,"/etl/_build/default/lib/libp2p/src/pb"},
                   {msg_name_prefix,"libp2p_"},
                   {msg_name_suffix,"_pb"},
                   {module_name_suffix,"_pb"},
                   {strings_as_binaries,false},
                   type_specs,
                   {i,"/etl/_build/default/lib/libp2p/src/proxy"},
                   {i,"/etl/_build/default/lib/libp2p/src/relay"},
                   {i,"/etl/_build/default/lib/libp2p/src/identify"},
                   {i,"/etl/_build/default/lib/libp2p/src/peerbook"},
                   {i,"/etl/_build/default/lib/libp2p/src/peerbook"},
                   {i,"/etl/_build/default/lib/libp2p/src/group"},
                   {i,"/etl/_build/default/lib/libp2p/src/group"}]
Unexpected error {parse_error,"libp2p_relay.proto",
                     [{missing_occurrence,['.',relay_ping],seq},
                      {missing_occurrence,['.',relay_ping],direction}]}
===> failed to compile /etl/_build/default/lib/libp2p/src/relay/libp2p_relay.proto: Unexpected error {parse_error,"libp2p_relay.proto",
                     [{missing_occurrence,['.',relay_ping],seq},
                      {missing_occurrence,['.',relay_ping],direction}]}
```

CC: @Vagabond @madninja 