### PR TITLE
make stop more graceful, when possible

### DIFF
--- a/src/group/libp2p_group_mgr.erl
+++ b/src/group/libp2p_group_mgr.erl
@@ -46,7 +46,7 @@ remove_group(Mgr, GroupID) ->
     gen_server:call(Mgr, {remove_group, GroupID}, infinity).
 
 stop_all(TID) ->
-    gen_server:call(reg_name(TID), stop_all, infinity).
+    gen_server:call(element(2, reg_name(TID)), stop_all, infinity).
 
 %% not implemented
 force_gc(Mgr) ->

--- a/src/group/libp2p_group_mgr.erl
+++ b/src/group/libp2p_group_mgr.erl
@@ -8,6 +8,7 @@
          mgr/1,
          add_group/4,
          remove_group/2,
+         stop_all/1,
          force_gc/1
         ]).
 
@@ -43,6 +44,9 @@ add_group(Mgr, GroupID, Module, Args) ->
 
 remove_group(Mgr, GroupID) ->
     gen_server:call(Mgr, {remove_group, GroupID}, infinity).
+
+stop_all(TID) ->
+    gen_server:call(reg_name(TID), stop_all, infinity).
 
 %% not implemented
 force_gc(Mgr) ->
@@ -86,15 +90,38 @@ handle_call({add_group, GroupID, Module, Args}, _From,
     {reply, Reply, State};
 handle_call({remove_group, GroupID}, _From, #state{tid = TID} = State) ->
     case libp2p_config:lookup_group(TID, GroupID) of
-        {ok, _Pid} ->
-            lager:info("removing group ~p", [GroupID]),
+        {ok, Pid} ->
+            Server = libp2p_group_relcast_sup:server(Pid),
+            lager:info("removing group ~p ~p  ~p", [GroupID, Pid, Server]),
+            Ref = erlang:monitor(process, Server),
             GroupSup = libp2p_swarm_group_sup:sup(TID),
+            libp2p_group_relcast_server:stop(Server),
+            receive
+                {'DOWN', Ref, process, Server, _} ->
+                    lager:info("got down from ~p", [Server]),
+                    ok
+            %% wait a max of 30s for the rocks-owning server to
+            %% gracefully shutdown
+            after 30000 ->
+                    ok
+            end,
+            %% then stop the sup and the workers, and maybe kill the
+            %% server if it's still hung
             _ = supervisor:terminate_child(GroupSup, GroupID),
             _ = supervisor:delete_child(GroupSup, GroupID),
             _ = libp2p_config:remove_group(TID, GroupID);
         false ->
             lager:warning("removing missing group ~p", [GroupID])
     end,
+    {reply, ok, State};
+handle_call(stop_all, _From,  #state{tid = TID} = State) ->
+    Groups = libp2p_config:all_groups(TID),
+    [begin
+         Server = libp2p_group_relcast_sup:server(Pid),
+         libp2p_group_relcast_server:stop(Server),
+         _ = libp2p_config:remove_group(TID, ID)
+     end
+     || {ID, Pid} <- Groups],
     {reply, ok, State};
 handle_call(force_gc, _From, #state{group_deletion_predicate = Predicate,
                                     storage_dir = Dir} = State) ->

--- a/src/group/libp2p_group_relcast_sup.erl
+++ b/src/group/libp2p_group_relcast_sup.erl
@@ -14,15 +14,21 @@ start_link(TID, GroupID, Args) ->
     supervisor:start_link(?MODULE, [TID, GroupID, Args]).
 
 init([TID, GroupID, Args]) ->
-    SupFlags = #{strategy => one_for_all},
+    SupFlags = #{
+                 strategy => one_for_all,
+                 intensity => 0,
+                 period => 1
+                },
     ChildSpecs =
         [
          #{ id => ?WORKERS,
             start => {libp2p_group_worker_sup, start_link, []},
-            type => supervisor
+            type => supervisor,
+            retart => transient
           },
          #{ id => server,
             start => {libp2p_group_relcast_server, start_link, [TID, GroupID, Args, self()]},
+            shutdown => 10000,
             restart => transient
           }
         ],

--- a/src/group/libp2p_group_relcast_sup.erl
+++ b/src/group/libp2p_group_relcast_sup.erl
@@ -24,7 +24,7 @@ init([TID, GroupID, Args]) ->
          #{ id => ?WORKERS,
             start => {libp2p_group_worker_sup, start_link, []},
             type => supervisor,
-            retart => transient
+            restart => transient
           },
          #{ id => server,
             start => {libp2p_group_relcast_server, start_link, [TID, GroupID, Args, self()]},

--- a/src/libp2p_cache.erl
+++ b/src/libp2p_cache.erl
@@ -45,22 +45,15 @@ start_link(TID) ->
     gen_server:start_link(reg_name(TID), ?MODULE, [TID], []).
 
 stop(TID) ->
-    gen_server:call(reg_name(TID), stop, infinity).
+    gen_server:call(element(2, reg_name(TID)), stop, infinity).
 
 reg_name(TID)->
     {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
+
 -spec insert(pid(), any(), any()) -> ok | {error, any()}.
 insert(Pid, Key, Value) ->
     gen_server:call(Pid, {insert, Key, Value}, 30000).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec lookup(pid(), any()) -> undefined | any().
 lookup(Pid, Key) ->
     lookup(Pid, Key, undefined).
@@ -69,10 +62,6 @@ lookup(Pid, Key) ->
 lookup(Pid, Key, Default) ->
     gen_server:call(Pid, {lookup, Key, Default}).
 
-%%--------------------------------------------------------------------
-%% @doc
-%% @end
-%%--------------------------------------------------------------------
 -spec delete(pid(), any()) -> ok | {error, any()}.
 delete(Pid, Key) ->
     gen_server:call(Pid, {delete, Key}).
@@ -104,7 +93,7 @@ handle_call({delete, Key}, _From, #state{dets=Dets}=State) ->
     Result = dets:delete(Dets, Key),
     {reply, Result, State};
 handle_call(stop, _From, State) ->
-    {stop, ok, normal, State};
+    {stop, normal, ok, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.

--- a/src/libp2p_cache.erl
+++ b/src/libp2p_cache.erl
@@ -12,6 +12,7 @@
 %% ------------------------------------------------------------------
 -export([
     start_link/1,
+    stop/1,
     insert/3,
     lookup/2, lookup/3,
     delete/2
@@ -42,6 +43,9 @@
 %% ------------------------------------------------------------------
 start_link(TID) ->
     gen_server:start_link(reg_name(TID), ?MODULE, [TID], []).
+
+stop(TID) ->
+    gen_server:call(reg_name(TID), stop, infinity).
 
 reg_name(TID)->
     {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
@@ -99,6 +103,8 @@ handle_call({lookup, Key, Default}, _From, #state{dets=Dets}=State) ->
 handle_call({delete, Key}, _From, #state{dets=Dets}=State) ->
     Result = dets:delete(Dets, Key),
     {reply, Result, State};
+handle_call(stop, _From, State) ->
+    {stop, ok, normal, State};
 handle_call(_Msg, _From, State) ->
     lager:warning("rcvd unknown call msg: ~p from: ~p", [_Msg, _From]),
     {reply, ok, State}.

--- a/src/libp2p_config.erl
+++ b/src/libp2p_config.erl
@@ -11,7 +11,7 @@
          listen_socket/0, lookup_listen_socket/2, lookup_listen_socket_by_addr/2, insert_listen_socket/4, remove_listen_socket/2, listen_sockets/1,
          lookup_connection_handlers/1, insert_connection_handler/2,
          lookup_stream_handlers/1, insert_stream_handler/2, remove_stream_handler/2,
-         insert_group/3, lookup_group/2, remove_group/2,
+         insert_group/3, lookup_group/2, remove_group/2, all_groups/1,
          insert_relay/2, lookup_relay/1, remove_relay/1,
          insert_relay_stream/3, lookup_relay_stream/2, remove_relay_stream/2,
          insert_relay_sessions/3, lookup_relay_sessions/2, remove_relay_sessions/2,
@@ -323,6 +323,11 @@ lookup_group(TID, GroupID) ->
 -spec remove_group(ets:tab(), string()) -> true.
 remove_group(TID, GroupID) ->
     remove_pid(TID, ?GROUP, GroupID).
+
+-spec all_groups(ets:tab()) -> [{string(), pid()}].
+all_groups(TID) ->
+    ets:match(TID, {{group, '$1'}, '$2'}).
+
 
 %%
 %% Relay

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -68,9 +68,9 @@ stop(Sup) ->
     ets:insert(TID, {shutdown, true}),
     Ref = erlang:monitor(process, Sup),
     %% do normal stops for everything that owns a rocks or dets instance
-    ok = libp2p_cache:stop(TID),
-    ok = libp2p_peerbook:stop(TID),
-    ok = libp2p_group_mgr:stop_all(TID),
+    catch libp2p_cache:stop(TID),
+    catch libp2p_peerbook:stop(TID),
+    catch libp2p_group_mgr:stop_all(TID),
 
     %% simulate supervisor shutdown, this should probably be a simple_one_for_one
     exit(Sup, shutdown),

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -68,9 +68,9 @@ stop(Sup) ->
     ets:insert(TID, {shutdown, true}),
     Ref = erlang:monitor(process, Sup),
     %% do normal stops for everything that owns a rocks or dets instance
-    catch libp2p_cache:stop(TID),
-    catch libp2p_peerbook:stop(TID),
-    catch libp2p_group_mgr:stop_all(TID),
+    ok = libp2p_cache:stop(TID),
+    ok = libp2p_peerbook:stop(TID),
+    ok = libp2p_group_mgr:stop_all(TID),
 
     %% simulate supervisor shutdown, this should probably be a simple_one_for_one
     exit(Sup, shutdown),

--- a/src/libp2p_swarm_auxiliary_sup.erl
+++ b/src/libp2p_swarm_auxiliary_sup.erl
@@ -48,7 +48,7 @@ init([TID, Opts]) ->
         period => 10
     },
     Specs = [
-        ?WORKER(?CACHE, libp2p_cache, [TID]),
+        ?WORKER(?CACHE, libp2p_cache, [TID])#{restart => transient},
         ?WORKER(nat, libp2p_nat_server, [TID]),
         ?WORKER(relay, libp2p_relay_server, [TID]),
         ?WORKER(proxy, libp2p_proxy_server, [TID, libp2p_proxy:limit(Opts)])

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -1,6 +1,6 @@
 -module(libp2p_peerbook).
 
--export([start_link/2, init/1, handle_call/3, handle_info/2, handle_cast/2, terminate/2]).
+-export([start_link/2, stop/1, init/1, handle_call/3, handle_info/2, handle_cast/2, terminate/2]).
 -export([keys/1, values/1,
          put/2, put/3, get/2,
          random/1, random/2, random/3, random/4,
@@ -373,6 +373,9 @@ init_gossip_data(Handle=#peerbook{tid=TID}) ->
 start_link(TID, SigFun) ->
     gen_server:start_link(reg_name(TID), ?MODULE, [TID, SigFun], [{hibernate_after, 5000}]).
 
+stop(TID) ->
+    gen_server:call(reg_name(TID), stop, infinity).
+
 reg_name(TID)->
     {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
 
@@ -428,6 +431,8 @@ init([TID, SigFun]) ->
 
 handle_call(update_this_peer, _From, State) ->
     {reply, update_this_peer(State), State};
+handle_call(stop, _From, State) ->
+    {stop, ok, normal, State};
 handle_call(Msg, _From, State) ->
     lager:warning("Unhandled call: ~p", [Msg]),
     {reply, ok, State}.

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -374,7 +374,7 @@ start_link(TID, SigFun) ->
     gen_server:start_link(reg_name(TID), ?MODULE, [TID, SigFun], [{hibernate_after, 5000}]).
 
 stop(TID) ->
-    gen_server:call(reg_name(TID), stop, infinity).
+    gen_server:call(element(2, reg_name(TID)), stop, infinity).
 
 reg_name(TID)->
     {local,libp2p_swarm:reg_name_from_tid(TID, ?MODULE)}.
@@ -432,7 +432,7 @@ init([TID, SigFun]) ->
 handle_call(update_this_peer, _From, State) ->
     {reply, update_this_peer(State), State};
 handle_call(stop, _From, State) ->
-    {stop, ok, normal, State};
+    {stop, normal, ok, State};
 handle_call(Msg, _From, State) ->
     lager:warning("Unhandled call: ~p", [Msg]),
     {reply, ok, State}.

--- a/test/group_twopc_SUITE.erl
+++ b/test/group_twopc_SUITE.erl
@@ -1,0 +1,139 @@
+-module(group_twopc_SUITE).
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+-export([
+         msg_loss_test/1
+        ]).
+
+all() ->
+    [ %% this test never ends, so only run it manually
+    ].
+
+init_per_testcase(TestCase, Config) ->
+    Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
+    Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]},
+                                        {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
+                                        {libp2p_nat, [{enabled, false}]},
+                                        {base_dir, ?config(base_dir, Config0)}]),
+    [{swarms, Swarms} | Config].
+
+end_per_testcase(_, Config) ->
+    Swarms = ?config(swarms, Config),
+    test_util:teardown_swarms(Swarms).
+
+msg_loss_test(Config) ->
+    Swarms =
+        [LeaderS, FollowerS1, FollowerS2] =
+        ?config(swarms, Config),
+
+    ct:pal("self ~p", [self()]),
+
+    test_util:connect_swarms(LeaderS, FollowerS1),
+    test_util:connect_swarms(LeaderS, FollowerS2),
+
+    test_util:await_gossip_groups(Swarms, 35),
+    test_util:await_gossip_streams(Swarms, 35),
+
+    Members = [libp2p_swarm:pubkey_bin(S) || S <- Swarms],
+
+    %% G1 takes input and broadcasts
+    LeaderArgs = [twopc_handler, [Members, true, undefined], [{create, true}]],
+    {ok, LeaderG} = libp2p_swarm:add_group(LeaderS, "twopc", libp2p_group_relcast, LeaderArgs),
+
+    Follower1ArgsC = [twopc_handler, [Members, 2, 1], [{create, true}]],
+    Follower1Args = [twopc_handler, [Members, 2, 1]],
+    {ok, Follower1G} = libp2p_swarm:add_group(FollowerS1, "twopc", libp2p_group_relcast,
+                                              Follower1ArgsC),
+
+    Follower2ArgsC = [twopc_handler, [Members, 3, 1], [{create, true}]],
+    Follower2Args = [twopc_handler, [Members, 3, 1]],
+    {ok, Follower2G} = libp2p_swarm:add_group(FollowerS2, "twopc", libp2p_group_relcast,
+                                              Follower2ArgsC),
+
+    timer:sleep(500), % wait a bit for groups to come up, need to
+                      % figure out how to wait for this better
+
+    Runner = self(),
+    Restarter =
+        spawn(
+          fun() ->
+                  receive go -> ok end,
+                  fun Restart(Groups) ->
+                          receive
+                              stop ->
+                                  Runner ! all_done,
+                                  ok;
+                              pause ->
+                                  receive
+                                      go ->
+                                          Restart(Groups)
+                                  end;
+                              print ->
+                                  lists:map(
+                                    fun({_S, G, _A}) ->
+                                            C = supervisor:which_children(G),
+                                            {server, P, _, _} = hd(C),
+                                            ct:pal("group ~p: ~p", [G, sys:get_state(P)])
+                                    end, Groups),
+                                  receive
+                                      go ->
+                                          Restart(Groups)
+                                  end
+                          after 0 ->
+                                  E = {Swarm, Group, Args} = lists:nth(rand:uniform(length(Groups)), Groups),
+
+                                  case rand:uniform(2) of
+                                      0 ->
+                                          ok = libp2p_group_relcast:handle_command(Group, stop);
+                                      2 ->
+                                          ok = libp2p_swarm:remove_group(Swarm, "twopc")
+                                  end,
+
+                                  lager:info("waiting on ~p", [Group]),
+                                  Ref = erlang:monitor(process, Group),
+                                  receive
+                                      {'DOWN', Ref, process, Group, _} ->
+                                          lager:info("test got down from ~p", [Group]),
+                                          ok
+                                  after 10000 ->
+                                          error(group_timeout)
+                                  end,
+                                  timer:sleep(1000),
+                                  {ok, Replacement} =
+                                      libp2p_swarm:add_group(Swarm, "twopc", libp2p_group_relcast, Args),
+                                  timer:sleep(50),
+                                  Groups1 = lists:delete(E, Groups),
+                                  Restart([{Swarm, Replacement, Args} | Groups1])
+                          end
+                  end([{FollowerS1, Follower1G, Follower1Args},
+                       {FollowerS2, Follower2G, Follower2Args}])
+          end),
+
+    L = fun Loop(250) ->
+                ok;
+            Loop(N) ->
+                case N of 3 -> Restarter ! go; _ -> ok end,
+                Timeout = case N of 1 -> 160000; _ -> 15000 end,
+                Start = erlang:monotonic_time(millisecond),
+                {ok, N} = libp2p_group_relcast:handle_command(LeaderG, {set_val, self(), N}),
+                receive
+                    {finished, N} ->
+                        End = erlang:monotonic_time(millisecond),
+                        ct:pal("setting var to ~p took ~p", [N, End - Start]),
+                        Loop(N + 1)
+                after Timeout ->
+                        Restarter ! print,
+                        error(timeout)
+                end
+        end,
+    L(1),
+
+    Restarter ! stop,
+    receive all_done -> ok
+    after 5000 -> ok % error(couldnt_stop_rec)
+    end,
+
+    %% error(whoa),
+    ok.
+

--- a/test/twopc_handler.erl
+++ b/test/twopc_handler.erl
@@ -1,0 +1,136 @@
+-module(twopc_handler).
+
+-behavior(relcast).
+
+-export([init/1,
+         handle_message/3,
+         handle_command/2,
+         callback_message/3,
+         serialize/1, deserialize/1,
+         restore/2]).
+
+-record(state,
+        {
+         m = m,
+         me,
+         v = v,
+         val = 0,
+         p = p,
+         prep_val,
+         r = r,
+         restarts = 0,
+         l = '------',
+         votes = #{},
+         commits = #{},
+         prop_val,
+         from,
+         leader,
+         total
+        }).
+
+init([Members, true, _]) ->
+    {ok, #state{leader = self, me = 1, total = length(Members)}};
+init([_Members, MyIdx, LeaderIdx]) ->
+    lager:info("member ~p init", [MyIdx]),
+    {ok, #state{leader = LeaderIdx, me = MyIdx}}.
+
+handle_message(Msg0, Index, State=#state{prop_val = Proposal,
+                                         votes = Votes,
+                                         total = Total,
+                                         commits = Commits,
+                                         from = From,
+                                         leader = self}) ->
+    Msg = binary_to_term(Msg0),
+    case Msg of
+        {prep_ack, PrepAckVal} when PrepAckVal == Proposal ->
+            lager:info("leader ~p got message from ~p: ~p", [self(), Index, Msg]),
+            Response =
+                case enough_votes(Index, Total, Proposal, Votes) of
+                    {true, Votes1} ->
+                        %%lager:info("accepted! ~p", [Proposal]),
+                        [{multicast, term_to_binary({commit, Proposal})}];
+                    {false, Votes1} ->
+                        %%lager:info("not accepted yet! ~p", [Proposal]),
+                        []
+                end,
+            {State#state{votes = maps:remove(Proposal - 1, Votes1)}, Response};
+        {commit_ack, CommitAckVal} when CommitAckVal == Proposal ->
+            lager:info("leader ~p got message from ~p: ~p", [self(), Index, Msg]),
+            case enough_votes(Index, Total, Proposal, Commits) of
+                {true, Commits1} ->
+                    %%lager:info("done! ~p", [Proposal]),
+                    From ! {finished, Proposal},
+                    {State#state{val = Proposal,
+                                 commits = maps:remove(Proposal - 5, Commits1)}, []};
+                {false, Commits1} ->
+                    %%lager:info("not done! ~p", [Proposal]),
+                    {State#state{commits = Commits1}, []}
+            end;
+        %% ignore self messages
+        {prepare, _} ->
+            ignore;
+        {commit, _} ->
+            ignore;
+        Unexpected ->
+            lager:info("leader got unexpected message from ~p: ~p", [Index, Unexpected]),
+            ignore
+    end;
+handle_message(Msg0, _Index, State=#state{val = Val,
+                                          prep_val = PrepVal,
+                                          leader = Leader}) ->
+    Msg = binary_to_term(Msg0),
+    lager:info("~p ~p got message from ~p: ~p", [State#state.me, self(), _Index, Msg]),
+    case Msg of
+        {prepare, NewPrepVal} ->
+            {State#state{prep_val = NewPrepVal},
+             [{unicast, Leader, term_to_binary({prep_ack, NewPrepVal})}]};
+        {commit, CommitVal} when CommitVal == PrepVal ->
+            {State#state{val = CommitVal, prep_val = undefined},
+             [{unicast, Leader, term_to_binary({commit_ack, CommitVal})}]};
+        {commit, CommitVal} when CommitVal =< Val -> % late resend?
+            ignore;
+        Else ->
+            lager:error("bad message ~p", [Else]),
+            error({noooooo, Else, Val, PrepVal})
+    end.
+
+handle_command({set_val, From, Val}, #state{leader = self} = State) ->
+    lager:info("set val ~p", [Val]),
+    {reply, {ok, Val}, [{multicast, term_to_binary({prepare, Val})}],
+     State#state{prop_val = Val, from = From}};
+handle_command({set_val, Val}, #state{} = State) ->
+    lager:info("bad set val ~p", [Val]),
+    {reply, {error, not_leader}, [], State};
+handle_command(stop, #state{} = State) ->
+    lager:info("stopping ~p", [State]),
+    %% this didn't work
+    %% foo = application:get_env(libp2p, glorp, bar),
+    {reply, ok, [{stop, 1}], State}.
+
+callback_message(_, _, _) ->
+    none.
+
+serialize(State) ->
+    lager:info("serialize ~p", [State]),
+    term_to_binary(State).
+
+deserialize(BinState) ->
+    State = binary_to_term(BinState),
+    lager:info("deserialize ~p", [State]),
+    State.
+
+restore(OldState = #state{restarts = Restarts}, _NewState) ->
+    lager:info("starting ~p ~p", [OldState, _NewState]),
+    {ok, OldState#state{restarts = Restarts + 1}}.
+
+enough_votes(I, T, N, Map) ->
+    %% lager:info("~p ~p ~p ~p", [I, T, N, Map]),
+    List = maps:get(N, Map, []),
+    L2 = [I | List],
+    case lists:member(I, List) of
+        true ->
+            %% error({double_vote, Map, idx, I, prop, N});
+            {length(List) == (T - 1), Map};
+        false ->
+            {length(L2) == (T - 1), Map#{N => L2}}
+    end.


### PR DESCRIPTION
our regular stop is too fast for rocks somehow.  Currently even on graceful shutdowns, we're potentially losing data on relcast groups.  This PR makes a number of changes to make graceful shutdowns easier at a higher level, and will eventually be accompanied by some higher level PRs that use this code.