### PR TITLE
stop gossiping connected peers for scalability reasons

### DIFF
--- a/src/libp2p_stream_stungun.erl
+++ b/src/libp2p_stream_stungun.erl
@@ -180,24 +180,15 @@ find_verifier(TID, FromAddr, {ok, TargetAddr}) ->
 find_verifier(TID, FromAddr, TargetAddr) ->
     lager:debug("finding peer for ~p not connected to ~p", [TargetAddr, FromAddr]),
     PeerBook = libp2p_swarm:peerbook(TID),
-    {ok, FromEntry} = libp2p_peerbook:get(PeerBook, FromAddr),
     TargetCryptoAddr = libp2p_crypto:p2p_to_pubkey_bin(TargetAddr),
     lager:debug("Target crypto addr ~p", [TargetCryptoAddr]),
     %% Gets the peers connected to the given FromAddr
-    FromConnected = libp2p_peer:connected_peers(FromEntry),
+    FromConnected = libp2p_peerbook:sessions(PeerBook),
     lager:debug("Our peers: ~p", [[libp2p_crypto:pubkey_bin_to_p2p(F) || F <- FromConnected]]),
     case lists:filter(fun(P) ->
                               %% Get the entry for the connected peer
                               {ok, Peer} = libp2p_peerbook:get(PeerBook, P),
-                              Res = not (lists:member(TargetCryptoAddr,
-                                                      libp2p_peer:connected_peers(Peer))
-                                         orelse libp2p_peer:pubkey_bin(Peer) == TargetCryptoAddr),
-                              lager:debug("peer ~p connected to ~p ? ~p",
-                                          [libp2p_crypto:pubkey_bin_to_p2p(libp2p_peer:pubkey_bin(Peer)),
-                                           [libp2p_crypto:pubkey_bin_to_p2p(F)
-                                            || F <- libp2p_peer:connected_peers(Peer)],
-                                           Res]),
-                              Res
+                              not (libp2p_peer:pubkey_bin(Peer) == TargetCryptoAddr)
                       end, FromConnected) of
         [] -> {error, not_found};
         Candidates ->

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -443,8 +443,8 @@ handle_info(stungun_retry, State=#state{observed_addrs=Addrs, tid=TID, stun_txns
         {ok, ObservedAddr} ->
             {PeerPath, TxnID} = libp2p_stream_stungun:mk_stun_txn(),
             %% choose a random connected peer to do stungun with
-            {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:pubkey_bin(TID)),
-            case [libp2p_crypto:pubkey_bin_to_p2p(P) || P <- libp2p_peer:connected_peers(MyPeer)] of
+            case [libp2p_crypto:pubkey_bin_to_p2p(P)
+                  || P <- libp2p_peerbook:sessions(libp2p_swarm:peerbook(TID))] of
                 [] ->
                     %% no connected peers
                     {noreply, State};

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -50,7 +50,7 @@ from_map(Map, SigFun) ->
                        end, maps:get(associations, Map, [])),
     Peer = #libp2p_peer_pb{pubkey=maps:get(pubkey, Map),
                            listen_addrs=[multiaddr:new(L) || L <- maps:get(listen_addrs, Map)],
-                           connected = maps:get(connected, Map),
+                           connected = maps:get(connected, Map, []),
                            nat_type=maps:get(nat_type, Map),
                            network_id=maps:get(network_id, Map, <<>>),
                            timestamp=Timestamp,
@@ -376,6 +376,7 @@ decode_list(Bin) ->
 %% @doc Decodes a given binary into a peer.
 -spec decode(binary()) -> peer().
 decode(Bin) when byte_size(Bin) > ?MAX_PEER_SIZE ->
+    lager:warning("local peer too large: ~p bytes", [byte_size(Bin)]),
     error(peer_too_large);
 decode(Bin) ->
     Msg = decode_unsafe(Bin),

--- a/test/peerbook_SUITE.erl
+++ b/test/peerbook_SUITE.erl
@@ -252,15 +252,13 @@ gossip_test(Config) ->
     %% The S2 entry in S1 should end up containing the address of S1
     %% as a connected peer
     ok = test_util:wait_until(fun() ->
-                                      {ok, S2PeerInfo} = libp2p_peerbook:get(S1PeerBook, S2Addr),
-                                      lists:member(S1Addr, libp2p_peer:connected_peers(S2PeerInfo))
+                                      lists:member(S1Addr, libp2p_peerbook:sessions(S2PeerBook))
                               end),
 
     %% and the S1 entry in S2 should end up containing the address of
     %% S2 as a connected peer
     ok = test_util:wait_until(fun() ->
-                                      {ok, S1PeerInfo} = libp2p_peerbook:get(S2PeerBook, S1Addr),
-                                      lists:member(S2Addr, libp2p_peer:connected_peers(S1PeerInfo))
+                                      lists:member(S2Addr, libp2p_peerbook:sessions(S1PeerBook))
                               end),
 
     %% Close the session by terminating the swarm
@@ -268,8 +266,7 @@ gossip_test(Config) ->
 
     %% After the session closes S1 should no longer have S2 as a connected peer
     ok = test_util:wait_until(fun() ->
-                                      {ok, S1Info} = libp2p_peerbook:get(S1PeerBook, S1Addr),
-                                      [] == libp2p_peer:connected_peers(S1Info)
+                                      [] == libp2p_peerbook:sessions(S1PeerBook)
                               end),
 
     ok.


### PR DESCRIPTION
change the code so that we don't use it anywhere internally, as well.