### PR TITLE
limit peer connection gossip, use random for eligible peers

### DIFF
--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -49,7 +49,7 @@ from_map(Map, SigFun) ->
                                {Type, #libp2p_association_list_pb{associations=AssocEntries}}
                        end, maps:get(associations, Map, [])),
     Connected0 = maps:get(connected, Map, []),
-    MaxConns = application:get_env(libp2p, max_connected_peers, 8),
+    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 8),
     Connected =
         case length(Connected0) =< MaxConns of
             true -> Connected0;

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -48,9 +48,16 @@ from_map(Map, SigFun) ->
     Assocs = lists:map(fun({Type, AssocEntries}) ->
                                {Type, #libp2p_association_list_pb{associations=AssocEntries}}
                        end, maps:get(associations, Map, [])),
+    Connected0 = maps:get(connected, Map, []),
+    MaxConns = application:get_env(libp2p, max_connected_peers, 8),
+    Connected =
+        case length(Connected0) =< MaxConns of
+            true -> Connected0;
+            _ -> rand_sub(Connected0, MaxConns)
+        end,
     Peer = #libp2p_peer_pb{pubkey=maps:get(pubkey, Map),
                            listen_addrs=[multiaddr:new(L) || L <- maps:get(listen_addrs, Map)],
-                           connected = maps:get(connected, Map),
+                           connected = Connected,
                            nat_type=maps:get(nat_type, Map),
                            network_id=maps:get(network_id, Map, <<>>),
                            timestamp=Timestamp,
@@ -58,6 +65,9 @@ from_map(Map, SigFun) ->
                            signed_metadata=encode_map(maps:get(signed_metadata, Map, #{}))
                           },
     sign_peer(Peer, SigFun).
+
+rand_sub(L, N) ->
+    lists:sublist(element(2, lists:unzip(lists:sort([{rand:uniform(), I} || I <- L]))), N).
 
 %% @doc Gets the public key for the given peer.
 -spec pubkey_bin(peer()) -> libp2p_crypto:pubkey_bin().
@@ -376,6 +386,7 @@ decode_list(Bin) ->
 %% @doc Decodes a given binary into a peer.
 -spec decode(binary()) -> peer().
 decode(Bin) when byte_size(Bin) > ?MAX_PEER_SIZE ->
+    lager:warning("local peer too large: ~p bytes", [byte_size(Bin)]),
     error(peer_too_large);
 decode(Bin) ->
     Msg = decode_unsafe(Bin),

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -336,7 +336,7 @@ handle_gossip_data(_StreamPid, DecodedList, Handle) ->
 
 -spec init_gossip_data(peerbook()) -> libp2p_group_gossip_handler:init_result().
 init_gossip_data(Peerbook) ->
-    case random(Peerbook, [], fun eligible_gossip_peer/1) of
+    case random(Peerbook, [], fun eligible_gossip_peer/1, 500) of
         {ok, Peer} -> {send, libp2p_peer:encode_list([Peer])};
         false -> ok
     end.


### PR DESCRIPTION
I think that this is a better version of #293.

Instead of dropping our connections, we limit the number of them we keep to a smaller number.

Also, instead of keeping an unscalable and seldom-updated bunch of state hanging around, we use random instead to select gossip peers.