### PR TITLE
add closed sort addrs function which maintains the ordered tuple in the returned list

### DIFF
--- a/src/libp2p_transport.erl
+++ b/src/libp2p_transport.erl
@@ -10,7 +10,7 @@
 
 
 -export_type([connection_handler/0]).
--export([start_link/2, for_addr/2, sort_addrs/2, connect_to/4, find_session/3,
+-export([start_link/2, for_addr/2, sort_addrs/2, sort_addrs_with_keys/2, connect_to/4, find_session/3,
          start_client_session/3, start_server_session/3]).
 
 
@@ -63,8 +63,8 @@ for_addr(TID, Addr) ->
 %% 4 = rfc1918 IPs (private/local IPs), 5 = Proxy transport
 %% @end
 %%--------------------------------------------------------------------
--spec sort_addrs(ets:tab(), [string()]) -> [string()].
-sort_addrs(TID, Addrs) ->
+-spec sort_addrs_with_keys(ets:tab(), [string()]) -> [{non_neg_integer(), string()}].
+sort_addrs_with_keys(TID, Addrs) ->
     TransportAddrsFun = fun(Transport) ->
         Matched = lists:filter(fun(Addr) ->
             case Transport:match_addr(Addr, TID) of
@@ -81,9 +81,12 @@ sort_addrs(TID, Addrs) ->
         [],
         libp2p_config:lookup_transports(TID)
     ),
-    {_, SortedAddrLists} = lists:unzip(lists:keysort(1, Transports)),
-    SortedAddrLists.
+    lists:keysort(1, Transports).
 
+-spec sort_addrs(ets:tab(), [string()]) -> [string()].
+sort_addrs(TID, Addrs) ->
+    {_, SortedAddrLists} = lists:unzip(sort_addrs_with_keys(TID, Addrs)),
+    SortedAddrLists.
 
 %% @doc Connect through a transport service. This is a convenience
 %% function that verifies the given multiaddr, finds the right


### PR DESCRIPTION
The existing sort_addrs function builds a list of the peer's various addresses, each defined as a tuple with the first element defined as an integer which determines the precedence of the address and which is used as the sort key

[
 {1, PublicAddr},
 {4, RFC1918Addr}
]

The returned list however looses the tuple and returns only the list of addresses in sorted order.

I need a version of this function which returns the full tuple so that the caller can know if the returned list contains a public IP ( which will always have a value of 1 )
