### PR TITLE
Avoid unnecessary pid/tid conversions when dialing

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -6,8 +6,7 @@
 
 -callback handle_data(State::any(), Ref::any(), {Msg::binary(), Seq::pos_integer()}) -> ok.
 -callback accept_stream(State::any(),
-                        Stream::pid(), Path::string()) ->
-    {ok, Ref::any()} | {error, term()}.
+                        Stream::pid(), Path::string()) -> Ref :: reference().
 -callback handle_ack(State::any(), Ref::any(), Seq::[pos_integer()], Reset::boolean()) -> ok.
 
 %% API
@@ -20,7 +19,9 @@
         { connection :: libp2p_connection:connection(),
           ack_module :: atom(),
           ack_state :: any(),
-          ack_ref :: any()
+          ack_ref :: any(),
+          reply_ref=make_ref() :: reference(),
+          data_queue=[] :: [binary()]
         }).
 
 -define(ACK_STREAM_TIMEOUT, timer:minutes(5)).
@@ -42,29 +43,18 @@ server(Connection, Path, _TID, Args) ->
     libp2p_framed_stream:server(?MODULE, Connection, [Path | Args]).
 
 init(server, Connection, [Path, AckModule, AckState | _]) ->
-    %% Catch errors from the handler module since the handling group
-    %% may have already stopped or crashed.
-    case (catch AckModule:accept_stream(AckState, self(), Path)) of
-        {ok, AckRef} ->
-            libp2p_connection:set_idle_timeout(Connection, ?ACK_STREAM_TIMEOUT),
-            {ok, #state{connection=Connection,
-                        ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}};
-        {error, Reason} ->
-            {stop, {error, Reason}};
-        {'EXIT', {noproc, _}} ->
-            %% Handle noproc silently since it's pretty common for a
-            %% relcast group to have gone away
-            {stop, normal};
-        Exit={'EXIT', _} ->
-            lager:warning("Stopping on accept_stream exit: ~s",
-                          [error_logger_lager_h:format_reason(Exit)]),
-            {stop, normal}
-    end;
+    libp2p_connection:set_idle_timeout(Connection, ?ACK_STREAM_TIMEOUT),
+    Ref = AckModule:accept_stream(AckState, self(), Path),
+    {ok, #state{connection=Connection, reply_ref=Ref,
+                ack_module=AckModule, ack_state=AckState}};
 init(client, Connection, [_Path, AckRef, AckModule, AckState | _]) ->
     libp2p_connection:set_idle_timeout(Connection, ?ACK_STREAM_TIMEOUT),
     {ok, #state{connection=Connection,
                 ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}}.
 
+handle_data(server, Data, State=#state{ack_ref=undefined}) ->
+    %% queue it until we get our ack ref
+    {noreply, State#state{data_queue=[Data|State#state.data_queue]}};
 handle_data(_Kind, Data, State=#state{ack_ref=AckRef, ack_module=AckModule, ack_state=AckState}) ->
     case libp2p_ack_stream_pb:decode_msg(Data, libp2p_ack_frame_pb) of
         #libp2p_ack_frame_pb{messages=Bin, seqs=Seq} when Bin /= [] ->
@@ -89,6 +79,26 @@ handle_send(_Kind, From, {Data, Seq}, Timeout, State=#state{}) ->
     Msg = #libp2p_ack_frame_pb{messages=[Data], seqs=[Seq]},
     {ok, {reply, From, pending}, libp2p_ack_stream_pb:encode_msg(Msg), Timeout, State#state{}}.
 
+handle_info(server, {Ref, AcceptResult}, State=#state{reply_ref=Ref}) ->
+    case AcceptResult of
+        {ok, AckRef} ->
+            erlang:demonitor(Ref, [flush]),
+            %% process any queued data in the order it was received
+            NewState = State#state{ack_ref=AckRef, data_queue=[]},
+            FinalState = lists:foldl(fun(Data, StateAcc) ->
+                                             {noreply, NewStateAcc} = handle_data(server, Data, StateAcc),
+                                             NewStateAcc
+                                     end, NewState, lists:reverse(State#state.data_queue)),
+            {noreply, FinalState};
+        {error, too_many} ->
+            {stop, normal, State};
+        {error, Reason} ->
+            lager:warning("Stopping on accept stream error: ~p", [Reason]),
+            {stop, {error, Reason}, State}
+    end;
+handle_info(server, {'DOWN', Ref, process, _, Reason}, State=#state{reply_ref=Ref}) ->
+    %% relcast server died while we were waiting for accept result
+    {stop, Reason, State};
 handle_info(_Kind, {send_ack, Seq, Reset}, State=#state{}) ->
     Msg = #libp2p_ack_frame_pb{seqs=Seq, reset=Reset},
     {noreply, State, libp2p_ack_stream_pb:encode_msg(Msg)}.

--- a/src/group/libp2p_gossip_stream.erl
+++ b/src/group/libp2p_gossip_stream.erl
@@ -14,14 +14,15 @@
 %% API
 -export([encode/2, encode/3]).
 %% libp2p_framed_stream
--export([server/4, client/2, init/3, handle_data/3]).
+-export([server/4, client/2, init/3, handle_data/3, handle_info/3]).
 
 
 -record(state,
         { connection :: libp2p_connection:connection(),
           handler_module :: atom(),
           handler_state :: any(),
-          path :: any()
+          path :: any(),
+          reply_ref=make_ref() :: reference()
         }).
 
 %% API
@@ -48,25 +49,12 @@ server(Connection, _Path, _TID, Args) ->
 init(server, Connection, [Path, HandlerModule, HandlerState]) ->
     lager:debug("initiating server with path ~p", [Path]),
     {ok, Session} = libp2p_connection:session(Connection),
-    %% Catch errors from the handler module in accepting a stream. The
-    %% most common occurence is during shutdown of a swarm where
-    %% ordering of the shutdown will cause the accept below to crash
-    %% noisily in the logs. This catch avoids that noise
-    case (catch HandlerModule:accept_stream(HandlerState, Session, self(), Path)) of
-        ok -> {ok, #state{connection=Connection,
-                          handler_module=HandlerModule,
-                          handler_state=HandlerState,
-                          path=Path}};
-        {error, too_many} ->
-            {stop, normal};
-        {error, Reason} ->
-            lager:warning("Stopping on accept stream error: ~p", [Reason]),
-            {stop, {error, Reason}};
-        Exit={'EXIT', _} ->
-            lager:warning("Stopping on accept_stream exit: ~s",
-                          [error_logger_lager_h:format_reason(Exit)]),
-            {stop, normal}
-    end;
+    HandlerModule:accept_stream(HandlerState, Session, self(), Path),
+    {ok, #state{connection=Connection,
+                handler_module=HandlerModule,
+                handler_state=HandlerState,
+                path=Path}};
+
 init(client, Connection, [Path, HandlerModule, HandlerState]) ->
     lager:debug("initiating client with path ~p", [Path]),
     {ok, #state{connection=Connection,
@@ -74,7 +62,7 @@ init(client, Connection, [Path, HandlerModule, HandlerState]) ->
                 handler_state=HandlerState,
                 path=Path}}.
 
-handle_data(_, Data, State=#state{handler_module=HandlerModule,
+handle_data(_Role, Data, State=#state{handler_module=HandlerModule,
                                   handler_state=HandlerState,
                                   path=Path}) ->
     #libp2p_gossip_frame_pb{key=Key, data=Bin} =
@@ -84,6 +72,22 @@ handle_data(_, Data, State=#state{handler_module=HandlerModule,
                                    {Path, apply_path_decode(Path, Bin)}),
     {noreply, State}.
 
+handle_info(server, {Ref, AcceptResult}, State=#state{reply_ref=Ref}) ->
+    case AcceptResult of
+        ok ->
+            erlang:demonitor(Ref, [flush]),
+            {noreply, State};
+        {error, too_many} ->
+            {stop, normal, State};
+        {error, Reason} ->
+            lager:warning("Stopping on accept stream error: ~p", [Reason]),
+            {stop, {error, Reason}, State}
+    end;
+handle_info(server, {'DOWN', Ref, process, _, Reason}, State=#state{reply_ref=Ref}) ->
+    %% gossip server died while we were waiting for accept result
+    {stop, Reason, State};
+handle_info(_, _, State) ->
+    {noreply, State}.
 
 apply_path_encode(?GROUP_PATH_V1, Data)->
     lager:debug("not compressing for path ~p..",[?GROUP_PATH_V1]),

--- a/src/group/libp2p_group_worker.erl
+++ b/src/group/libp2p_group_worker.erl
@@ -588,7 +588,7 @@ update_metadata(Data=#data{}) ->
       ]),
     Data.
 
--spec dial(Parent::pid(), TID::ets:tid(), Peer::string(), Module::atom(),
+-spec dial(Parent::pid(), TID::ets:tab(), Peer::string(), Module::atom(),
             Args::[any()], SupportedPaths::[string()])->
                     {'ok', StreamPid::pid(), Path::string()} |
                     {'error', any()}.
@@ -614,7 +614,7 @@ dial(Parent, TID, Peer, Module, Args, SupportedPaths) ->
         end,
     DialFun(SupportedPaths).
 
--spec do_dial(TID::ets:tid(), Peer::string(), Module::atom(),
+-spec do_dial(TID::ets:tab(), Peer::string(), Module::atom(),
             Args::[any()], Path::string())->
                     {'ok', StreamPid::pid()} |
                     {'error', any()}.

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -307,7 +307,7 @@ connect(TID, Addr, Options, Timeout) ->
 
 % Stream
 %
--spec dial(pid() | atom(), string(), string()) -> {ok, libp2p_connection:connection()} | {error, term()}.
+-spec dial(pid() | ets:tab(), string(), string()) -> {ok, libp2p_connection:connection()} | {error, term()}.
 dial(Sup, Addr, Path) when is_pid(Sup) ->
     dial(tid(Sup), Addr, Path);
 dial(TID, Addr, Path) ->

--- a/src/libp2p_swarm.erl
+++ b/src/libp2p_swarm.erl
@@ -307,7 +307,7 @@ connect(TID, Addr, Options, Timeout) ->
 
 % Stream
 %
--spec dial(pid(), string(), string()) -> {ok, libp2p_connection:connection()} | {error, term()}.
+-spec dial(pid() | atom(), string(), string()) -> {ok, libp2p_connection:connection()} | {error, term()}.
 dial(Sup, Addr, Path) when is_pid(Sup) ->
     dial(tid(Sup), Addr, Path);
 dial(TID, Addr, Path) ->

--- a/test/ack_stream_SUITE.erl
+++ b/test/ack_stream_SUITE.erl
@@ -52,8 +52,10 @@ ack_test(Config) ->
     ok.
 
 accept_stream({Pid, _}, StreamPid, Path) ->
+    Ref = make_ref(),
     Pid ! {accept_stream, StreamPid, Path},
-    {ok, {server, self()}}.
+    StreamPid ! {Ref, {ok, {server, self()}}},
+    Ref.
 
 handle_data({Pid, Response}, Ref, [{Seq, Bin}]) ->
     Pid ! {handle_data, Ref, Bin, Seq},

--- a/test/nat_SUITE.erl
+++ b/test/nat_SUITE.erl
@@ -100,7 +100,7 @@ server(_Config) ->
 
     meck:new(nat, [no_link, passthrough]),
     meck:expect(nat, discover, fun() ->
-        {ok, context}
+        {ok, {natpmp, context}}
     end),
     meck:expect(nat, add_port_mapping, fun(_Context, tcp, _Port, _ExtPort, 0) ->
         {error, error};


### PR DESCRIPTION
This seems to add a dialyzer error that I do not have time to chase down.