### PR TITLE
when doing NAT, make sure the transport knows about nat server crashes

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -544,7 +544,8 @@ handle_info({nat_discovered, InternalAddr, ExternalAddr}, State=#state{tid=TID})
     end;
 handle_info(no_nat, State) ->
     {noreply, State#state{negotiated_nat = false}};
-handle_info({'DOWN', _Ref, process, Pid, _Reason}, State=#state{nat_server = {_NatRef, NatPid}}) when Pid == NatPid ->
+handle_info({'DOWN', Ref, process, Pid, _Reason}, State=#state{nat_server = {NatRef, NatPid}})
+  when Pid == NatPid andalso Ref == NatRef ->
     {noreply, State#state{nat_server = undefined, negotiated_nat = false}};
 handle_info({'DOWN', _Ref, process, Pid, Reason}, State=#state{tid=TID}) when Reason /= normal; Reason /= shutdown ->
     %% check if this is a listen socket pid

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -542,6 +542,8 @@ handle_info({nat_discovered, InternalAddr, ExternalAddr}, State=#state{tid=TID})
             lager:warning("no listener detected for ~p", [InternalAddr]),
             {noreply, State}
     end;
+handle_info(no_nat, State) ->
+    {noreply, State#state{negotiated_nat = false}};
 handle_info({'DOWN', _Ref, process, Pid, _Reason}, State=#state{nat_server = {_NatRef, NatPid}}) when Pid == NatPid ->
     {noreply, State#state{nat_server = undefined, negotiated_nat = false}};
 handle_info({'DOWN', _Ref, process, Pid, Reason}, State=#state{tid=TID}) when Reason /= normal; Reason /= shutdown ->

--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -65,7 +65,8 @@
          tid :: ets:tab(),
          stun_txns=#{} :: #{libp2p_stream_stungun:txn_id() => string()},
          observed_addrs=sets:new() :: sets:set({string(), string()}),
-         negotiated_nat=false :: boolean()
+         negotiated_nat=false :: boolean(),
+         nat_server :: undefined | {reference(), pid()}
         }).
 
 -define(DEFAULT_MAX_TCP_CONNECTIONS, 1024).
@@ -529,11 +530,20 @@ handle_info({nat_discovered, InternalAddr, ExternalAddr}, State=#state{tid=TID})
             %% remove any observed addresses
             [ true = libp2p_config:remove_listener(TID, MultiAddr) || MultiAddr <- distinct_observed_addrs(State#state.observed_addrs) ],
             libp2p_config:insert_listener(TID, [ExternalAddr], ListenPid),
+            %% monitor the nat server, so we can unset this if it crashes
+            {ok, Pid} = libp2p_config:lookup_nat(TID),
+            Ref = erlang:monitor(process, Pid),
+
             %% TODO if the nat type has resolved to 'none' here we should change it to static
-            {noreply, State#state{negotiated_nat=true, observed_addrs=sets:new()}};
+            {noreply, State#state{negotiated_nat = true,
+                                  observed_addrs = sets:new(),
+                                  nat_server = {Ref, Pid}}};
         _ ->
+            lager:warning("no listener detected for ~p", [InternalAddr]),
             {noreply, State}
     end;
+handle_info({'DOWN', _Ref, process, Pid, _Reason}, State=#state{nat_server = {_NatRef, NatPid}}) when Pid == NatPid ->
+    {noreply, State#state{nat_server = undefined, negotiated_nat = false}};
 handle_info({'DOWN', _Ref, process, Pid, Reason}, State=#state{tid=TID}) when Reason /= normal; Reason /= shutdown ->
     %% check if this is a listen socket pid
     case libp2p_config:lookup_listen_socket(TID, Pid) of

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -117,7 +117,8 @@ handle_info(renew, #state{tid=TID, transport_tcp=Pid, internal_address=IntAddr, 
             %% this might lead to a period of undialability
             ok = remove_multi_addr(TID, ExtAddr0, ExtPort0),
             lager:warning("failed to renew lease for port ~p: ~p", [{IntPort, ExtPort0}, _Reason]),
-            _ = erlang:send_after(5000, self(), renew),
+            Pid ! no_nat,
+            _ = erlang:send_after(timer:minutes(5), self(), renew),
             {noreply, State}
     end;
 handle_info({'DOWN', _Ref, process, TransportPid, Reason}, #state{internal_port=IntPort, external_port=ExtPort}=State) ->

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -114,9 +114,11 @@ handle_info(renew, #state{tid=TID, transport_tcp=Pid, internal_address=IntAddr, 
             end,
             {noreply, State#state{external_address=ExtAddr1, external_port=ExtPort1, lease=Lease, since=Since}};
         {error, _Reason} ->
+            %% this might lead to a period of undialability
             ok = remove_multi_addr(TID, ExtAddr0, ExtPort0),
             lager:warning("failed to renew lease for port ~p: ~p", [{IntPort, ExtPort0}, _Reason]),
-            {stop, renew_failed, State}
+            _ = erlang:send_after(5000, self(), renew),
+            {noreply, State}
     end;
 handle_info({'DOWN', _Ref, process, TransportPid, Reason}, #state{internal_port=IntPort, external_port=ExtPort}=State) ->
     lager:warning("tcp transport ~p went down: ~p cleaning up", [TransportPid, Reason]),

--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -116,7 +116,7 @@ handle_info(renew, #state{tid=TID, transport_tcp=Pid, internal_address=IntAddr, 
         {error, _Reason} ->
             ok = remove_multi_addr(TID, ExtAddr0, ExtPort0),
             lager:warning("failed to renew lease for port ~p: ~p", [{IntPort, ExtPort0}, _Reason]),
-            {stop, renew_failed}
+            {stop, renew_failed, State}
     end;
 handle_info({'DOWN', _Ref, process, TransportPid, Reason}, #state{internal_port=IntPort, external_port=ExtPort}=State) ->
     lager:warning("tcp transport ~p went down: ~p cleaning up", [TransportPid, Reason]),


### PR DESCRIPTION
we've seen cases where the nat server crashes from not being able to renew and then tcp transport never retries establishing a nat connection.