### PR TITLE
Reduce logging level for NAT registration failure

### DIFF
--- a/src/nat/libp2p_nat_server.erl
+++ b/src/nat/libp2p_nat_server.erl
@@ -84,7 +84,7 @@ handle_call({register, TransportPid, MultiAddr, IntPort}, _From, #state{tid=TID,
             {reply, ok, State#state{transport_tcp=TransportPid, internal_address=MultiAddr, internal_port=IntPort,
                                     external_address=ExtAddr, external_port=ExtPort, lease=Lease, since=Since}};
         {error, _Reason1} ->
-            lager:error("failed to add port (~p) mapping ~p", [{IntPort, CachedExtPort}, _Reason1]),
+            lager:info("failed to add port (~p) mapping with upnp: ~p", [{IntPort, CachedExtPort}, _Reason1]),
             {reply, {error, _Reason1}, State}
     end;
 handle_call(_Msg, _From, State) ->


### PR DESCRIPTION
Reduce the lager logging level of nat registration failure. a failure trying to add a port mapping via upnp or nat-pmp indicates that there is no nat in front of the miner or one that doesn't support upnp/nat-pmp. this in and of itself is not an error.