### PR TITLE
Check we have an inbound connection in stungun in the right place

### DIFF
--- a/src/libp2p_stream_stungun.erl
+++ b/src/libp2p_stream_stungun.erl
@@ -18,8 +18,7 @@
 
 -record(client_state, {
           txn_id :: binary(),
-          handler :: pid(),
-          direction :: inbound | outbound
+          handler :: pid()
          }).
 
 %%
@@ -52,9 +51,8 @@ client(Connection, Args) ->
 server(Connection, Path, _TID, Args) ->
     libp2p_framed_stream:server(?MODULE, Connection, [Path | Args]).
 
-init(client, Connection, [TxnID, Handler, TID]) ->
-    {ok, SessionPid} = libp2p_connection:session(Connection),
-    {ok, #client_state{txn_id=TxnID, handler=Handler, direction=libp2p_config:lookup_session_direction(TID, SessionPid)}};
+init(client, _Connection, [TxnID, Handler, _TID]) ->
+    {ok, #client_state{txn_id=TxnID, handler=Handler}};
 init(server, Connection, ["/dial/"++Path, _, TID]) ->
     {_, ObservedAddr0} = libp2p_connection:addr_info(Connection),
     [{"ip4", IP}, {"tcp", PortStr0}] = multiaddr:protocols(ObservedAddr0),
@@ -125,10 +123,17 @@ init(server, Connection, ["/dial/"++Path, _, TID]) ->
                     {stop, normal, ?SYMMETRIC_NAT}
             end
     end;
-init(server, Connection, ["/reply/"++TxnID, Handler, _TID]) ->
+init(server, Connection, ["/reply/"++TxnID, Handler, TID]) ->
     lager:debug("got reply confirmation for  ~p", [TxnID]),
-    {LocalAddr, _} = libp2p_connection:addr_info(Connection),
-    Handler ! {stungun_reply, list_to_integer(TxnID), LocalAddr},
+    {ok, SessionPid} = libp2p_connection:session(Connection),
+    case libp2p_config:lookup_session_direction(TID, SessionPid) of
+        inbound ->
+            {LocalAddr, _} = libp2p_connection:addr_info(Connection),
+            Handler ! {stungun_reply, list_to_integer(TxnID), LocalAddr};
+        _ ->
+            lager:info("ignoring IP address confirmation on outbound session"),
+            ok
+    end,
     {stop, normal};
 init(server, _Connection, ["/verify/"++Info, _Handler, TID]) ->
     {TxnID, TargetAddr} = string:take(Info, "/", true),
@@ -147,13 +152,10 @@ init(server, _Connection, ["/verify/"++Info, _Handler, TID]) ->
             {stop, normal, ?FAILED}
     end.
 
-handle_data(client, Code, State=#client_state{txn_id=TxnID, handler=Handler, direction=inbound}) ->
+handle_data(client, Code, State=#client_state{txn_id=TxnID, handler=Handler}) ->
     lager:debug("Got code ~p for txnid ~p", [Code, TxnID]),
     {NatType, _Info} = to_nat_type(Code),
     Handler ! {stungun_nat, TxnID, NatType},
-    {stop, normal, State};
-handle_data(client, Code, State=#client_state{txn_id=TxnID, direction=outbound}) ->
-    lager:notice("Got code ~p for txnid ~p on outbound session, ignoring", [Code, TxnID]),
     {stop, normal, State};
 
 handle_data(server, _,  _) ->


### PR DESCRIPTION
Prior to the fix for tagging connection directions correctly, the
incorrect connection tracking allowed this code to usually work. However
we were checking for an inbound session in the wrong place. We really
care about dial confirmation from a peer we don't have an outbound
connection to. The prior check was checking the connection direction on
the reply from the intermediate host which, when you have no listen
addresses, will always be outbound, so stungun could never resolve the
NAT state.