### PR TITLE
fix: Reset port counter to start from 1025

### DIFF
--- a/src/nat/libp2p_nat.erl
+++ b/src/nat/libp2p_nat.erl
@@ -250,7 +250,7 @@ retry_matrix(Context, Try, Port) ->
 increment_port(Port) when Port < 65535-1 ->
     Port+1;
 increment_port(Port) ->
-    Port.
+    1025.
 
 %%--------------------------------------------------------------------
 %% @doc


### PR DESCRIPTION
Before, `increment_port` would increment the port to test all the ports up to 65535 and then get stuck in 65535. Now, when it reaches 65535, it resets back to 1025 and continues incrementing in the next calls.

_I am familiar with functional languages, but I am not familiar with Erlang syntax, **please feel free to correct my PR**_.