### PR TITLE
shuffle send order 

### DIFF
--- a/src/group/libp2p_group_relcast_server.erl
+++ b/src/group/libp2p_group_relcast_server.erl
@@ -489,7 +489,7 @@ dispatch_next_messages(State) ->
                    [] ->
                        State;
                    Workers ->
-                       take_while([W || W <- Workers], State)
+                       take_while(shuffle(Workers), State)
                end,
     %% attempt to deliver some stuff in the pending queue
     maps:fold(
@@ -520,6 +520,8 @@ dispatch_next_messages(State) ->
               end
       end, NewState, NewState#state.pending).
 
+shuffle(List) ->
+    [X || {_,X} <- lists:sort([{rand:uniform(), N} || N <- List])].
 
 -spec filter_ready_workers(#state{}) -> [#worker{}].
 filter_ready_workers(State=#state{}) ->


### PR DESCRIPTION
shuffle the message order so as not to accidentally penalize the end of the list, as there have been reports of validators at the end of the list being penalized inadvertently.