### PR TITLE
Clear the peerbook if it's not corrupted

### DIFF
--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -522,6 +522,8 @@ open_rocks(DataDir, CFOpts, TTL, clean) ->
                 _ ->
                     open_rocks(DataDir, CFOpts, TTL, clear)
             end;
+        {error, _} ->
+            open_rocks(DataDir, CFOpts, TTL, clear);
         {ok, _DB} = OK -> OK
     end;
 open_rocks(DataDir, CFOpts, TTL, repaired) ->


### PR DESCRIPTION
Alternative here is not to match on "Corruption" in the db_open error and try a repair in all error cases.