### PR TITLE
Up the limit of random connections to gossip

### DIFF
--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -49,12 +49,8 @@ from_map(Map, SigFun) ->
                                {Type, #libp2p_association_list_pb{associations=AssocEntries}}
                        end, maps:get(associations, Map, [])),
     Connected0 = maps:get(connected, Map, []),
-    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 8),
-    Connected =
-        case length(Connected0) =< MaxConns of
-            true -> Connected0;
-            _ -> rand_sub(Connected0, MaxConns)
-        end,
+    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 200),
+    Connected = rand_sub(Connected0, MaxConns),
     Peer = #libp2p_peer_pb{pubkey=maps:get(pubkey, Map),
                            listen_addrs=[multiaddr:new(L) || L <- maps:get(listen_addrs, Map)],
                            connected = Connected,


### PR DESCRIPTION
Problems to solve: Currently we are gossiping a maximum of 8 connections which is not a lot on something like a seed node where may have 10,000 or more. Additionally, `lists/sublist/2` allows for the length of a sublist to be longer than the input - so using a conditional doesn't make much sense (except to avoid the randomization/sorting but on a short list, it costs almost nothing anyway).

Solution: Up to the default limit to 200, remove the conditional test.  In my testing on this, we could _probably_ store closer to 1500 connections and be under the 50 kb gossip limit. 

Addresses #352 