### PR TITLE
Truncate connected sessions, better rand_sub

### DIFF
--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -49,7 +49,7 @@ from_map(Map, SigFun) ->
                                {Type, #libp2p_association_list_pb{associations=AssocEntries}}
                        end, maps:get(associations, Map, [])),
     Connected0 = maps:get(connected, Map, []),
-    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 200),
+    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 20),
     Connected = rand_sub(Connected0, MaxConns),
     Peer = #libp2p_peer_pb{pubkey=maps:get(pubkey, Map),
                            listen_addrs=[multiaddr:new(L) || L <- maps:get(listen_addrs, Map)],
@@ -62,8 +62,10 @@ from_map(Map, SigFun) ->
                           },
     sign_peer(Peer, SigFun).
 
+rand_sub(L, N) when length(L) =< N -> L;
 rand_sub(L, N) ->
-    lists:sublist(element(2, lists:unzip(lists:sort([{rand:uniform(), I} || I <- L]))), N).
+   Len = length(L),
+   lists:usort([ lists:nth(rand:uniform(Len), L) || _ <- lists:seq(1, N) ]).
 
 %% @doc Gets the public key for the given peer.
 -spec pubkey_bin(peer()) -> libp2p_crypto:pubkey_bin().

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -558,7 +558,8 @@ mk_this_peer(CurrentPeer, State=#state{tid=TID}) ->
                           filter_rfc1918_addresses(ListenAddrs0)
                   end,
     NetworkID = libp2p_swarm:network_id(TID),
-    ConnectedAddrs = maps:values(State#state.sessions),
+    MaxConns = application:get_env(libp2p, max_peers_to_gossip, 20),
+    ConnectedAddrs = lists:sublist(maps:values(State#state.sessions), MaxConns*2),
     %% Copy data from current peer
     case CurrentPeer of
         undefined ->


### PR DESCRIPTION
Problem to solve: When the number of connected sessions is very high (seed nodes, router) the `rand_sub/2` function takes a long time to compute a list of random peers to gossip.

Solution: First, we will truncate the input list to double the maximum peers to gossip, second, we will use a much more efficient selection function. My tests show about a 6x speed improvement on a list of size 10,000 entries where we want 20 random entries from that list compared with the original rand_sub implementation.