### PR TITLE
Mj/die with a quickness

### DIFF
--- a/src/libp2p_session.erl
+++ b/src/libp2p_session.erl
@@ -6,7 +6,7 @@
 
 -export_type([stream_handler/0]).
 
--export([ping/1, open/1, close/1, close/3, close_state/1, goaway/1, streams/1, addr_info/2, identify/3]).
+-export([ping/1, open/1, close/1, close/2, close_state/1, goaway/1, streams/1, addr_info/2, identify/3]).
 
 -export([dial/2, dial_framed_stream/4]).
 
@@ -23,7 +23,11 @@ open(Pid) ->
 
 -spec close(pid()) -> ok.
 close(Pid) ->
-    try close(Pid, normal, 5000) of
+    close(Pid, normal).
+
+-spec close(pid(), term()) -> ok.
+close(Pid, Reason) ->
+    try close(Pid, Reason, 5000) of
         Res -> Res
     catch
         exit:timeout ->

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -117,12 +117,9 @@ handle_cast(Msg, State) ->
     lager:warning("Unhandled cast: ~p", [Msg]),
     {noreply, State}.
 
-
-terminate(Reason, #state{tid=TID}) ->
-    lists:foreach(fun({Addr, Pid}) ->
-                          libp2p_config:remove_session(TID, Addr),
-                          catch libp2p_session:close(Pid, Reason)
-                  end, libp2p_config:lookup_sessions(TID)).
+terminate(Reason, _State) ->
+    lager:warning("going down ~p", [Reason]),
+    ok.
 
 %% Internal
 %%

--- a/src/libp2p_swarm_server.erl
+++ b/src/libp2p_swarm_server.erl
@@ -121,7 +121,7 @@ handle_cast(Msg, State) ->
 terminate(Reason, #state{tid=TID}) ->
     lists:foreach(fun({Addr, Pid}) ->
                           libp2p_config:remove_session(TID, Addr),
-                          catch libp2p_session:close(Pid, Reason, infinity)
+                          catch libp2p_session:close(Pid, Reason)
                   end, libp2p_config:lookup_sessions(TID)).
 
 %% Internal


### PR DESCRIPTION
waiting infinity for sessions to close was causing the swarm_server to
never fully die when it was terminated.
Why it's own 10s timeout in libp2p_swarm_sup did not come along and
brutally kill the process is still a mystery to me.

The supervisor is a one_for_all, if anything is going down, it's taking all
the sessions with it already. We'll still log to know what is killing
the server.
