### PR TITLE
Reduce ack stream inactivity timeout to 1 minute

### DIFF
--- a/src/group/libp2p_ack_stream.erl
+++ b/src/group/libp2p_ack_stream.erl
@@ -24,7 +24,7 @@
           data_queue=[] :: [binary()]
         }).
 
--define(ACK_STREAM_TIMEOUT, timer:minutes(5)).
+-define(ACK_STREAM_TIMEOUT, timer:minutes(1)).
 
 %% API
 %%


### PR DESCRIPTION
To hopefully identify dead connections sooner and possibly to work around possible holes in the relcast ack protocol, lower the inactivity timeout to 1 minute.