### PR TITLE
Avoid gossiping uninteresting peers

### DIFF
--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -556,9 +556,7 @@ open_rocks(DataDir, CFOpts, TTL, clear) ->
     end.
 
 eligible_gossip_peer(Peer) ->
-    Limit = application:get_env(libp2p, eligible_peer_connectedness, 3),
-    libp2p_peer:is_dialable(Peer)
-        andalso length(libp2p_peer:connected_peers(Peer)) >= Limit.
+    libp2p_peer:is_dialable(Peer).
 
 -spec mk_this_peer(libp2p_peer:peer() | undefined, #state{}) -> {ok, libp2p_peer:peer()} | {error, term()}.
 mk_this_peer(CurrentPeer, State=#state{tid=TID}) ->

--- a/src/peerbook/libp2p_peerbook.erl
+++ b/src/peerbook/libp2p_peerbook.erl
@@ -103,7 +103,7 @@ put(#peerbook{tid=TID, stale_time=StaleTime}=Handle, PeerList0, Prevalidated) ->
     AllowRFC1918 = is_rfc1918_allowed(TID),
     NewPeers = lists:foldl(
                  fun(NewPeer, Acc) ->
-                         case libp2p_peer:listen_addrs() == [] of
+                         case libp2p_peer:listen_addrs(NewPeer) == [] of
                              true ->
                                  %% no need to store a peer with no listen addresses
                                  %% and it it will make it easier to get an updated version


### PR DESCRIPTION
* Try to avoid sending peers with no listen addresses around, or storing them
* Finally filter RFC1918 peers
* Don't worry too much about how many connections the peer claims to have