### PR TITLE
Remove extremely noisy logging statment

### DIFF
--- a/src/group/libp2p_group_gossip_server.erl
+++ b/src/group/libp2p_group_gossip_server.erl
@@ -70,7 +70,6 @@ handle_data(_Pid, StreamPid, Kind, Peer, Key, TID, {Path, Bin}) ->
             _ ->
                 {Path, Bin}
         end,
-    lager:info("gossip data from peer ~p ~p", [Kind, Peer]),
     %% check the cache, see the lookup_handler function for details
     case lookup_handler(TID, Key) of
         error ->


### PR DESCRIPTION
This line is probably not very valuable, and absolutely spamming `console.log`