### PR TITLE
Try to prevent stungunning relayed peers

### DIFF
--- a/src/libp2p_transport_tcp.erl
+++ b/src/libp2p_transport_tcp.erl
@@ -492,7 +492,7 @@ handle_info(stungun_retry, State=#state{observed_addrs=Addrs, tid=TID, stun_txns
             {PeerPath, TxnID} = libp2p_stream_stungun:mk_stun_txn(),
             %% choose a random connected peer to do stungun with
             {ok, MyPeer} = libp2p_peerbook:get(libp2p_swarm:peerbook(TID), libp2p_swarm:pubkey_bin(TID)),
-            case [libp2p_crypto:pubkey_bin_to_p2p(P) || P <- libp2p_peer:connected_peers(MyPeer)] of
+            case [libp2p_crypto:pubkey_bin_to_p2p(P) || P <- libp2p_peer:connected_peers(MyPeer), libp2p_peer:has_public_ip(P)] of
                 [] ->
                     %% no connected peers
                     Ref = erlang:send_after(30000, self(), stungun_retry),


### PR DESCRIPTION
Filter the list of connected peers to exclude peers that do not have a public address per suggestion of @ci-work in #415 

I don't think relayed nodes are the problem except the subset of relayed nodes that is running behind some CGNAT or similar system. The easiest way to avoid the issue is to stungun just those peers of which it is known they have a public ip address.

I have been running this change for almost 24h now and it hasn't yet picked up a relay address. I will deploy this to one more node and have it run over the weekend to limit the amount of luck involved.

Some potential problems I considered:
1. **What if there are only relayed peers connected to this node?**
    It shouldn't matter since it will start a relay if it fails a few times in a row.

Addresses #415 