### PR TITLE
Enable force setting network id

### DIFF
--- a/src/libp2p_swarm_sup.erl
+++ b/src/libp2p_swarm_sup.erl
@@ -82,6 +82,10 @@ init([Name, Opts]) ->
     ets:insert(TID, {?SUP, self()}),
     ets:insert(TID, {?NAME, Name}),
     ets:insert(TID, {?OPTS, Opts}),
+    case proplists:get_value(force_network_id, Opts) of
+        undefined -> true;
+        NetworkID -> ets:insert(TID, {network_id, NetworkID})
+    end,
     % Get or generate our keys
     {PubKey, SigFun, ECDHFun} = init_keys(Opts),
     ets:insert(TID, {?ADDRESS, libp2p_crypto:pubkey_to_bin(PubKey)}),

--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -286,10 +286,10 @@ network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id = <<>>}}) ->
 network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id=ID}}) ->
     ID.
 
+%% @doc We will only store peers when our own id is defined and the
+%% same as the peer network id
 network_id_allowable(Peer, MyNetworkID) ->
-    network_id(Peer) == MyNetworkID
-    orelse libp2p_peer:network_id(Peer) == undefined
-    orelse MyNetworkID == undefined.
+    MyNetworkID /= undefined andalso network_id(Peer) == MyNetworkID.
 
 %% @doc Returns whether the peer is listening on a public, externally
 %% visible IP address.


### PR DESCRIPTION
Problem to solve: When a node isn't following the chain (like a seed node), then we need a way to force set a network id so that the peerbook won't store entries with an undefined network id, or a network id that isn't the same as ours. This leads to seed nodes holding entries and gossiping nodes it shouldn't really be storing or gossiping.

Solution: Enable a new option in the swarm supervisor to force set a network id if supplied by the Erlang environment in `force_network_id`. PR works with and requires helium/blockchain-core#1287 and helium/blockchain-core#1384 and a forthcoming PR in miner to add the environment variable to the appropriate config.src templates