### PR TITLE
always match peer to self netid

### DIFF
--- a/src/peerbook/libp2p_peer.erl
+++ b/src/peerbook/libp2p_peer.erl
@@ -289,7 +289,7 @@ network_id(#libp2p_signed_peer_pb{peer=#libp2p_peer_pb{network_id=ID}}) ->
 %% @doc We will only store peers when our own id is defined and the
 %% same as the peer network id
 network_id_allowable(Peer, MyNetworkID) ->
-    MyNetworkID /= undefined andalso network_id(Peer) == MyNetworkID.
+    network_id(Peer) == MyNetworkID.
 
 %% @doc Returns whether the peer is listening on a public, externally
 %% visible IP address.


### PR DESCRIPTION
assuming we've defined network ids on nodes where it really matters, this change would continue to ensure that they only peer up with nodes on the same network. however, if the network id is `undefined` we aren't picky about peering up with others where the network id is also `undefined`