### PR TITLE
fix tests for network id changes

### DIFF
--- a/test/group_gossip_SUITE.erl
+++ b/test/group_gossip_SUITE.erl
@@ -26,11 +26,13 @@ all() ->
 init_per_testcase(seed_test = TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
     %% Set up S2 as the seed.
-    [S2] = test_util:setup_swarms(1, [
-                                       {libp2p_group_gossip, [{peerbook_connections, 0}]},
-                                       {force_network_id, <<"GossipTestSuite">>},
-                                       {base_dir, ?config(base_dir, Config0)}
-                                     ]),
+    [S2] = test_util:setup_swarms(
+             1,
+             [
+              {libp2p_group_gossip, [{peerbook_connections, 0}]},
+              {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
+              {base_dir, ?config(base_dir, Config0)}
+             ]),
 
     S2ListenAddrs = libp2p_swarm:listen_addrs(S2),
 
@@ -40,6 +42,7 @@ init_per_testcase(seed_test = TestCase, Config) ->
                                         [ {peerbook_connections, 0},
                                           {seed_nodes, S2ListenAddrs}
                                         ]},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {force_network_id, <<"GossipTestSuite">>},
                                        {base_dir, ?config(base_dir, Config0)}
                                      ]),
@@ -60,7 +63,7 @@ init_per_testcase(TestCase, Config) ->
                                          [{peerbook_connections, 1},
                                           {peer_cache_timeout, 100}]
                                         },
-                                        {force_network_id, <<"GossipTestSuite">>},
+                                        {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                         {base_dir, ?config(base_dir, Config0)} ]),
     [{swarms, Swarms} | Config].
 
@@ -147,7 +150,7 @@ forwards_compat_gossip_test(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -155,7 +158,7 @@ forwards_compat_gossip_test(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -204,14 +207,14 @@ backwards_compat_gossip_test(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
     %% S2 represents an old swarm, so dont specifiy the gossip protocol in the config let it use default
     [S2] = test_util:setup_swarms(1, [
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -263,7 +266,7 @@ same_path_gossip_test1(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -271,7 +274,7 @@ same_path_gossip_test1(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -319,7 +322,7 @@ same_path_gossip_test2(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 
@@ -327,7 +330,7 @@ same_path_gossip_test2(Config) ->
                                        {libp2p_group_gossip, [{peerbook_connections, 1},
                                                               {peer_cache_timeout, 100},
                                                               {supported_gossip_paths, ["gossip/1.0.2", "gossip/1.0.0"]}  ]},
-                                       {force_network_id, <<"GossipTestSuite">>},
+                                       {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]},
                                        {base_dir, ?config(base_dir, Config)}
                                      ]),
 

--- a/test/group_relcast_SUITE.erl
+++ b/test/group_relcast_SUITE.erl
@@ -23,21 +23,24 @@ all() ->
 
 init_per_testcase(defer_test = TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
-    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000},
+                                                           {force_network_id, <<"GossipTestSuite">>}]},
                                         {libp2p_group_gossip, [{peer_cache_timeout, 50}]},
                                         {libp2p_nat, [{enabled, false}]},
                                         {base_dir, ?config(base_dir, Config0)}]),
     [{swarms, Swarms} | Config];
 init_per_testcase(close_test = TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
-    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000}]},
+    Swarms = test_util:setup_swarms(2, [{libp2p_peerbook, [{notify_time, 1000},
+                                                           {force_network_id, <<"GossipTestSuite">>}]},
                                         {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
                                         {libp2p_nat, [{enabled, false}]},
                                         {base_dir, ?config(base_dir, Config0)}]),
     [{swarms, Swarms} | Config];
 init_per_testcase(TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
-    Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000}]},
+    Swarms = test_util:setup_swarms(3, [{libp2p_peerbook, [{notify_time, 1000},
+                                                           {force_network_id, <<"GossipTestSuite">>}]},
                                         {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
                                         {libp2p_nat, [{enabled, false}]},
                                         {base_dir, ?config(base_dir, Config0)}]),
@@ -92,7 +95,7 @@ unicast_test(Config) ->
     %% Receive message from G1 as handled by G2
     receive
         {handle_msg, 1, <<"unicast1">>} -> ok
-    after 15000 ->
+    after 30000 ->
               ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
               error(timeout)
     end,
@@ -100,7 +103,7 @@ unicast_test(Config) ->
     %% Receive the message from G2 as handled by G3
     receive
         {handle_msg, 2, <<"unicast2">>} -> ok
-    after 15000 ->
+    after 30000 ->
               ct:pal("Messages: ~p", [erlang:process_info(self(), [messages])]),
               error(timeout)
     end,
@@ -317,7 +320,7 @@ handle_msg(Resp) ->
     end.
 
 receive_messages(Acc, ExpectedCount) ->
-    Ref = erlang:send_after(20000, self(), receive_message_timeout),
+    Ref = erlang:send_after(40000, self(), receive_message_timeout),
     receive_messages_(Acc, ExpectedCount, Ref).
 
 receive_messages_(Acc, 0, Ref) ->

--- a/test/identify_SUITE.erl
+++ b/test/identify_SUITE.erl
@@ -11,7 +11,9 @@ all() ->
 
 init_per_testcase(TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
-    Swarms = test_util:setup_swarms([{base_dir, ?config(base_dir, Config0)}]),
+    Swarms = test_util:setup_swarms([{base_dir, ?config(base_dir, Config0)},
+                                     {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}
+                                    ]),
     [{swarms, Swarms}| Config].
 
 end_per_testcase(_, Config) ->

--- a/test/libp2p_secure_framed_stream_SUITE.erl
+++ b/test/libp2p_secure_framed_stream_SUITE.erl
@@ -60,7 +60,7 @@ end_per_testcase(_, _Config) ->
 %% @end
 %%--------------------------------------------------------------------
 invalid_key_exchange(_Config) ->
-    SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
+    SwarmOpts = [{libp2p_nat, [{enabled, false}]}, {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}],
     Version = "securetest/1.0.0",
 
     {ok, ServerSwarm} = libp2p_swarm:start(insecure_server_test, SwarmOpts),
@@ -129,7 +129,7 @@ invalid_key_exchange(_Config) ->
     ok.
 
 key_exchange(_Config) ->
-    SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
+    SwarmOpts = [{libp2p_nat, [{enabled, false}]},{libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}],
     Version = "securetest/1.0.0",
 
     {ok, ServerSwarm} = libp2p_swarm:start(secure_server_test, SwarmOpts),
@@ -175,7 +175,7 @@ key_exchange(_Config) ->
     ok.
 
 stream(_Config) ->
-    SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
+    SwarmOpts = [{libp2p_nat, [{enabled, false}]}, {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}],
     Version = "securetest/1.0.0",
 
     {ok, ServerSwarm} = libp2p_swarm:start(secure_server_echo_test, SwarmOpts),
@@ -243,7 +243,7 @@ stream(_Config) ->
 
 
 failed_stream(_Config) ->
-    SwarmOpts = [{libp2p_nat, [{enabled, false}]}],
+    SwarmOpts = [{libp2p_nat, [{enabled, false}]},{libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}],
     Version = "securetest/1.0.0",
 
     {ok, ServerSwarm} = libp2p_swarm:start(secure_server_fail_qecho_test, SwarmOpts),

--- a/test/proxy_SUITE.erl
+++ b/test/proxy_SUITE.erl
@@ -59,7 +59,8 @@ end_per_testcase(_, _Config) ->
 %%--------------------------------------------------------------------
 basic(_Config) ->
     SwarmOpts = [{libp2p_nat, [{enabled, false}]},
-                 {libp2p_group_gossip, [{peer_cache_timeout, 100}]}
+                 {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
+                 {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}
                 ],
     Version = "proxytest/1.0.0",
 
@@ -216,7 +217,8 @@ limit_exceeded(_Config) ->
     SwarmOpts = [
         {libp2p_nat, [{enabled, false}]},
         {libp2p_group_gossip, [{peer_cache_timeout, 100}]},
-        {libp2p_proxy, [{limit, 0}]}
+        {libp2p_proxy, [{limit, 0}]},
+        {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}
     ],
     Version = "proxytest/1.0.0",
 
@@ -245,7 +247,7 @@ limit_exceeded(_Config) ->
         {libp2p_framed_stream, server, [libp2p_stream_proxy_test, self(), CSwarm]}
     ),
 
-   % Relay needs a public ip now, not just a circuit address
+    %% Relay needs a public ip now, not just a circuit address
     meck:new(libp2p_transport_tcp, [no_link, passthrough]),
     meck:expect(libp2p_transport_tcp, is_public, fun(_) -> false end),
     meck:new(libp2p_peer, [no_link, passthrough]),
@@ -317,7 +319,7 @@ limit_exceeded(_Config) ->
             _ ->
                 false
         end
-    end),
+    end, 200, 200),
     ct:pal("CCircuitAddress ~p", [CCircuitAddress]),
     ct:pal("ACircuitAddress ~p", [ACircuitAddress]),
     % Avoid trying another address

--- a/test/relay_SUITE.erl
+++ b/test/relay_SUITE.erl
@@ -58,7 +58,8 @@ end_per_testcase(_, _Config) ->
 %%--------------------------------------------------------------------
 basic(_Config) ->
     SwarmOpts = [
-        {libp2p_nat, [{enabled, false}]}
+        {libp2p_nat, [{enabled, false}]},
+        {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}
     ],
     Version = "relaytest/1.0.0",
 
@@ -119,7 +120,7 @@ basic(_Config) ->
                 _ -> false
             end
         end,
-        100,
+        200,
         250
     ),
 

--- a/test/swarm_SUITE.erl
+++ b/test/swarm_SUITE.erl
@@ -13,7 +13,9 @@ all() ->
 
 init_per_testcase(TestCase, Config) ->
     Config0 = test_util:init_base_dir_config(?MODULE, TestCase, Config),
-    Swarms = test_util:setup_swarms(1, [{base_dir, ?config(base_dir, Config0)}]),
+    Swarms = test_util:setup_swarms(1, [{base_dir, ?config(base_dir, Config0)},
+                                        {libp2p_peerbook, [{force_network_id, <<"GossipTestSuite">>}]}
+                                       ]),
     [{swarms, Swarms} | Config0].
 
 end_per_testcase(stop_test, _Config) ->
@@ -30,9 +32,18 @@ accessor_test(Config) ->
 
     {ok, PubKey, _, _} = libp2p_swarm:keys(S1),
     true = libp2p_crypto:pubkey_to_bin(PubKey) == libp2p_swarm:pubkey_bin(S1),
-    case libp2p_swarm:opts(S1) of
-        [{libp2p_nat, [{enabled, false}]}, {base_dir, _}] -> ok;
-        [{base_dir, _}, {libp2p_nat, [{enabled, false}]}] -> ok
+    Opts = libp2p_swarm:opts(S1),
+    case proplists:get_value(libp2p_peerbook, Opts) of
+        undefined -> error(peerbook_undefined);
+        _ -> ok
+    end,
+    case proplists:get_value(libp2p_nat, Opts) of
+        undefined -> error(peerbook_undefined);
+        _ -> ok
+    end,
+    case proplists:get_value(base_dir, Opts) of
+        undefined -> error(peerbook_undefined);
+        _ -> ok
     end,
     "swarm" ++ _ = atom_to_list(libp2p_swarm:name(S1)),
 

--- a/test/test_util.erl
+++ b/test/test_util.erl
@@ -109,7 +109,7 @@ await_gossip_group(Swarm, Swarms, Timeout0) ->
       end, Timeout, 100).
 
 await_gossip_groups(Swarms) ->
-    await_gossip_groups(Swarms, 30).
+    await_gossip_groups(Swarms, 45).
 
 await_gossip_groups(Swarms, Timeout) ->
     lists:foreach(fun(S) ->
@@ -117,7 +117,7 @@ await_gossip_groups(Swarms, Timeout) ->
                   end, Swarms).
 
 await_gossip_streams(Swarms) ->
-    await_gossip_streams(Swarms, 30).
+    await_gossip_streams(Swarms, 45).
 
 await_gossip_streams(Swarms, Timeout) when is_list(Swarms) ->
     lists:foreach(fun(S) ->
@@ -127,7 +127,7 @@ await_gossip_streams(Swarm, Timeout) ->
     await_gossip_streams([Swarm], Timeout).
 
 await_gossip_stream(Swarm, Timeout0) ->
-    Timeout = Timeout0 * 10,
+    Timeout = Timeout0 * 5,
     GossipGroup = libp2p_swarm:gossip_group(Swarm),
     GroupPids = libp2p_group_gossip:connected_pids(GossipGroup, all),
     test_util:wait_until(
@@ -137,7 +137,7 @@ await_gossip_stream(Swarm, Timeout0) ->
               catch _:_ ->
                  false
               end
-      end, Timeout, 100).
+      end, Timeout, 200).
 
 
 


### PR DESCRIPTION
adjust the tests to use the network id correctly, and tweak timers to make tests more consistent.