### PR TITLE
resolve proto compile errors

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,7 @@
 ]}.
 
 {plugins, [
-    {rebar3_gpb_plugin, "2.15.0"},
+    {rebar3_gpb_plugin, "2.22.1"},
     covertool
 ]}.
 


### PR DESCRIPTION
this replicates a fix that was also added to https://github.com/helium/proto/pull/116 to resolve rebar_gpb_plugin errors that break compilation. in the case of libp2p protos, the following error is resolved:

```
===> Stack trace to the error location:
[{gpb_compile,list_io,
              ["/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/relay/libp2p_relay.proto",
               [{i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src"},
                {o_erl,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/pb"},
                {o_hrl,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/pb"},
                {msg_name_prefix,"libp2p_"},
                {msg_name_suffix,"_pb"},
                {module_name_suffix,"_pb"},
                {strings_as_binaries,false},
                type_specs,
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/relay"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/peerbook"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/peerbook"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/group"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/group"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/proxy"},
                {i,"/Users/jeff/workspace/work/helium/blockchain-core/_build/default/lib/libp2p/src/identify"}]],
              []}
```